### PR TITLE
Guide on Custom Output Adapters

### DIFF
--- a/docs/concepts/generators.md
+++ b/docs/concepts/generators.md
@@ -16,3 +16,21 @@ Generators are responsible for generating specific outputs based on input data. 
 * [CodeFromDescriptionGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code\_from\_description\_generator.rb): Generates code based on a description and the technologies used.
 * [DescriptionFromCodeGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/description\_from\_code\_generator.rb): Generates a description of the code passed in to it.
 * [CodeFromBlueprintGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code\_from\_blueprint\_generator.rb): Generates code based on a blueprint, a blueprint description, and a description of the desired code.
+
+## Custom Output Adapters Example
+
+To further extend the functionality of generators, you can create custom Output Adapters. These adapters define the structure and format of the AI-generated output, acting as a bridge between the raw AI responses and the structured data your application expects.
+
+### Creating a Custom Output Adapter
+
+See the codebase example in `lib/sublayer/components/output_adapters` for reference. Here's a basic outline of creating a custom Output Adapter:
+
+- **Define the Adapter Class:** Create a new class that implements necessary methods like `initialize` and `properties`.
+
+- **Properties Method:** Define the properties your adapter will handle—these are typically formatted as an array of `OpenStruct` objects that describe the structure of the expected output.
+
+- **Integration with Generators:** Use your custom adapter within a generator by specifying it in the `llm_output_adapter` method.
+
+This setup allows you to customize how the data flows from the generator to its end use, providing flexibility and specificity in handling AI-generated data.
+
+By leveraging custom Output Adapters, you can tailor the output of your Generators to fit the exact needs of your application, enhancing clarity and customization.

--- a/docs/custom_components/output-adapters.md
+++ b/docs/custom_components/output-adapters.md
@@ -39,6 +39,7 @@ class MyGenerator < Sublayer::Generators::Base
 end
 ```
 
+
 ### Examples
 
 Below are links to the built-in output adapters in Sublayer and are fully tested against example generators. You can use these as a reference when building your own output adapters.
@@ -47,3 +48,48 @@ Below are links to the built-in output adapters in Sublayer and are fully tested
 - [List of Strings](https://github.com/sublayerapp/sublayer/blob/e57d4e44117cec6e6c0f750d53b499df7bc66ca1/lib/sublayer/components/output_adapters/list_of_strings.rb)
 - [String Selection from List](https://github.com/sublayerapp/sublayer/blob/e57d4e44117cec6e6c0f750d53b499df7bc66ca1/lib/sublayer/components/output_adapters/string_selection_from_list.rb)
 - [Named Strings](https://github.com/sublayerapp/sublayer/blob/e57d4e44117cec6e6c0f750d53b499df7bc66ca1/lib/sublayer/components/output_adapters/named_strings.rb)
+
+## Creating a Custom Output Adapter: An Example
+
+To provide a clearer understanding, here's a step-by-step example of creating a custom Output Adapter:
+
+### Step 1: Define the Adapter Class
+
+Start by defining a new class for your output adapter, inheriting from the base:
+
+```ruby
+class MyCustomAdapter < Sublayer::Components::OutputAdapters::Base
+  def initialize(name, description)
+    @name = name
+    @description = description
+  end
+```
+
+### Step 2: Define Properties
+
+Next, define the required `properties` method:
+
+```ruby
+  def properties
+    [OpenStruct.new(name: @name, type: 'string', description: @description, required: true)]
+  end
+end
+```
+
+### Step 3: Integrate with a Generator
+
+Use your custom adapter within a generator:
+
+```ruby
+class ExampleGenerator < Sublayer::Generators::Base
+  llm_output_adapter class: MyCustomAdapter,
+    name: "example",
+    description: "An example of a custom output adapter"
+
+  def prompt
+    "Generate a response based on specific criteria."
+  end
+end
+```
+
+By following these steps, you can create and integrate custom output adapters tailored to your specific use case.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -65,11 +65,11 @@ module Sublayer
 
       def prompt
         <<-PROMPT
-          You are an expert programmer in \#{@technologies.join(", ")}.
+          You are an expert programmer in \\#{@technologies.join(", ")}.
 
-          You are tasked with writing code using the following technologies: \#{@technologies.join(", ")}.
+          You are tasked with writing code using the following technologies: \\#{@technologies.join(", ")}.
 
-          The description of the task is \#{@description}
+          The description of the task is \\#{@description}
 
           Take a deep breath and think step by step before you start coding.
         PROMPT
@@ -103,6 +103,12 @@ generator = Sublayer::Generators::CodeFromDescriptionGenerator.new(description: 
 
 puts generator.generate
 ```
+
+### Step 5 - Explore Advanced Customization
+
+For deeper integration, you might consider creating custom Output Adapters. These adapters define how the generator output is structured and formatted to fit your specific application needs.
+
+Explore this in-depth [example of creating custom Output Adapters]({% link docs/custom_components/output-adapters.md %}).
 
 ### Next Steps
 


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion: Include an in-depth example in the documentation on how to create custom Output Adapters, leveraging the example in the codebase (lib/sublayer/components/output_adapters). This would help clarify their usage and customization.