### PR TITLE
Build Simple Project Guide via CLI

### DIFF
--- a/docs/guides/building_with_cli.md
+++ b/docs/guides/building_with_cli.md
@@ -1,0 +1,77 @@
+---
+title: "Building with CLI"
+parent: Guides
+nav_order: 4
+---
+
+# Building a Simple Sublayer Project Using CLI
+
+This guide provides a step-by-step walkthrough on building a simple Sublayer project using the Command Line Interface (CLI). Follow along to create your first project seamlessly.
+
+## Prerequisites
+
+Before you begin, ensure you have the following:
+
+- Ruby installed on your system.
+- Access to the terminal or command line.
+- Familiarity with basic command line operations.
+
+## Step-by-Step Walkthrough
+
+1. **Install Sublayer Gem**
+   
+   Firstly, ensure you have the Sublayer gem installed. You can do this via:
+   
+   ```shell
+   gem install sublayer
+   ```
+
+2. **Initialize a New Project**
+
+   Use the Sublayer CLI to create a new project. Run:
+   
+   ```shell
+   sublayer new my_project
+   ```
+
+   This command sets up a new directory `my_project` with the necessary files.
+
+3. **Navigate to Your Project Directory**
+
+   Change directory into your newly created project:
+
+   ```shell
+   cd my_project
+   ```
+
+4. **Configure Environment Variables**
+
+   Make sure your OpenAI API key is configured correctly:
+   
+   ```shell
+   export OPENAI_API_KEY="your-api-key"
+   ```
+
+5. **Create a Generator**
+
+   Use the built-in generator command to create a new Generator within your project:
+
+   ```shell
+   sublayer generate:generator --description "Example generator"
+   ```
+
+6. **Implement a Simple Task**
+
+   Using the created generator, implement a simple function like a text response mechanism or data processor.
+
+7. **Run Your Project**
+
+   Execute your main script to see your project in action:
+
+   ```shell
+   ruby my_project.rb
+   ```
+
+## Conclusion
+
+Following these steps, you can set up and run a simple Sublayer project using the CLI. Modify and expand your project to explore more features offered by Sublayer.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -65,11 +65,11 @@ module Sublayer
 
       def prompt
         <<-PROMPT
-          You are an expert programmer in \#{@technologies.join(", ")}.
+          You are an expert programmer in \\#{@technologies.join(", ")}.
 
-          You are tasked with writing code using the following technologies: \#{@technologies.join(", ")}.
+          You are tasked with writing code using the following technologies: \\#{@technologies.join(", ")}.
 
-          The description of the task is \#{@description}
+          The description of the task is \\#{@description}
 
           Take a deep breath and think step by step before you start coding.
         PROMPT
@@ -91,7 +91,7 @@ Try generating your own generator with our interactive code generator below:
 
 Require the Sublayer gem and your generator and call `generate`!
 
-Here's an example of how you might use the \`CodeFromDescriptionGenerator\` above:
+Here's an example of how you might use the `CodeFromDescriptionGenerator` above:
 
 ```ruby
 # ./example.rb
@@ -103,6 +103,10 @@ generator = Sublayer::Generators::CodeFromDescriptionGenerator.new(description: 
 
 puts generator.generate
 ```
+
+### Extended Guide
+
+For a more detailed step-by-step guide on building projects using the CLI, check out the [Building with CLI Guide]({% link docs/guides/building_with_cli.md %})
 
 ### Next Steps
 


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Create a new section or sub-page in the documentation that provides a step-by-step example of building a simple Sublayer project using the CLI. The current documentation provides scattered information but lacks a cohesive guide that takes a user from start to finish. This would greatly enhance the UX for new users. Include this in a new file 'docs/guides/building_with_cli.md' linked from 'docs/quick_start.md'.
potential files to change: docs/quick_start.md,docs/guides/building_with_cli.md