### PR TITLE
Document Output Adapter Types in Generators

### DIFF
--- a/docs/concepts/generators.md
+++ b/docs/concepts/generators.md
@@ -7,6 +7,19 @@ nav_order: 1
 
 Generators are responsible for generating specific outputs based on input data. They focus on a single generation task and do not perform any actions or complex decision-making. Generators are the building blocks of the Sublayer framework.
 
+### Supported Output Adapter Types
+
+To cater to diverse needs, multiple output adapter types are available:
+
+- **Single String**: Outputs a single string.
+- **List of Strings**: Outputs a list of strings.
+- **Named Strings**: Outputs a set of named strings.
+- **List of Named Strings**: Outputs a list of named string sets, allowing you to define multiple attributes for each set.
+- **Single Integer**: Outputs a single integer.
+- **String Selection from List**: Outputs a string selected from a provided list.
+
+These adapters help in structuring the kind of output the LLM should produce by understanding the specific types of outputs required which assists in configuring the generation task appropriately.
+
 ### Try making your own generator:
 
 <iframe src="https://blueprints.sublayer.com/interactive-code-generator/sublayer-generators?example=true" width="100%" height="500px"></iframe>


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Update the 'Generators' section in the documentation to include information about various output adapter types available in Sublayer. Currently, the documentation briefly mentions 'single string' adapters, but there are other types such as 'list of strings', 'named strings', 'list of named strings', 'single integer', and 'string selection from list'. Including these will provide a more comprehensive understanding of the generator framework and assist developers in choosing the appropriate adapter for their needs.
potential files to change: docs/concepts/generators.md