### PR TITLE
Document MakeRspecTestsPassTask

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -2,6 +2,7 @@
 title: Core Concepts
 nav_order: 3
 ---
+
 # Core Concepts
 
 The framework is broken up into three core concepts: Generators, Actions, and Agents.
@@ -11,3 +12,7 @@ Browse the links below to go more in depth into each of these concepts:
 * [Generators]({% link docs/concepts/generators.md %})
 * [Actions]({% link docs/concepts/actions.md %})
 * [Agents]({% link docs/concepts/agents.md %})
+
+## Task: MakeRspecTestsPassTask
+
+A newly introduced task, `MakeRspecTestsPassTask`, plays a significant role in Sublayer's capability for test-driven development. This task assists in running RSpec tests in an automated loop, modifying the related implementation files until the tests pass successfully. It is primarily built to streamline the development process by ensuring continuous alignment of implementation against defined tests. This is especially valuable for maintaining code quality and reliability in projects that require automated TDD. To implement this task, developers need to specify the relevant implementation file and the test command which will automatically be handled by the framework.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -2,6 +2,7 @@
 title: "Quick Start"
 nav_order: 2
 ---
+
 # Quick Start
 
 Sublayer is made up of three main concepts: Generators, Actions, and Agents. These concepts combine to create powerful AI-powered applications in a simple and easy-to-use interface.
@@ -9,6 +10,10 @@ Sublayer is made up of three main concepts: Generators, Actions, and Agents. The
 You can think of a Sublayer Generator as an object that takes some string inputs and runs them through an LLM to generate some new string output.
 
 In this example, we'll create a simple generator that takes a description of code and the technologies to use and generates code using an LLM like GPT-4.
+
+### Automated Test-Driven Development with MakeRspecTestsPassTask
+
+Sublayer includes tasks like the 'MakeRspecTestsPassTask', which is designed to run your tests in a continuous loop, adjusting the implementation until all tests pass. This task is essential for users interested in automating test-driven development (TDD) processes. By integrating this task, developers can ensure their codebase adheres to defined specifications and behaves as expected over time, making the development process smoother and more efficient. To get started with 'MakeRspecTestsPassTask', simply define the implementation file and the test command to use.
 
 ***
 
@@ -65,11 +70,11 @@ module Sublayer
 
       def prompt
         <<-PROMPT
-          You are an expert programmer in \#{@technologies.join(", ")}.
+          You are an expert programmer in \\#{@technologies.join(", ")}.
 
-          You are tasked with writing code using the following technologies: \#{@technologies.join(", ")}.
+          You are tasked with writing code using the following technologies: \\#{@technologies.join(", ")}.
 
-          The description of the task is \#{@description}
+          The description of the task is \\#{@description}
 
           Take a deep breath and think step by step before you start coding.
         PROMPT
@@ -91,7 +96,7 @@ Try generating your own generator with our interactive code generator below:
 
 Require the Sublayer gem and your generator and call `generate`!
 
-Here's an example of how you might use the \`CodeFromDescriptionGenerator\` above:
+Here's an example of how you might use the `CodeFromDescriptionGenerator` above:
 
 ```ruby
 # ./example.rb


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Add documentation about newly added tasks such as 'MakeRspecTestsPassTask'. This task is responsible for running tests in a loop until they pass, modifying the implementation file when needed. The task is crucial for users who are interested in automated test-driven development. Including this information will help enhance understanding and usability of the framework for test automation.
potential files to change: docs/quick_start.md, docs/concepts/index.md