### PR TITLE
Expand 'Custom Trigger' Examples

### DIFF
--- a/docs/guides/build-a-custom-trigger.md
+++ b/docs/guides/build-a-custom-trigger.md
@@ -6,6 +6,8 @@ parent: Guides
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/UqaSRtoaOh4?si=fdcnLXfuSlIgobdL" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 
+## Create a Hello World Agent with Time Interval Trigger
+
 Let's make a simple time interval trigger for a hello world sublayer agent
 
 ```bash
@@ -62,3 +64,74 @@ bundle install
   ```bash
   ruby hello_world_agent.rb
   ```
+
+## Additional Examples of Custom Triggers
+
+### File Change Trigger Example
+Create a custom trigger that activates when a specific file is changed.
+
+```ruby
+class FileChangeTrigger < Sublayer::Triggers::Base
+  def initialize(file_path)
+    @file_path = file_path
+  end
+
+  def setup(agent)
+    Listen.to(File.dirname(@file_path)) do |modified, added, removed|
+      if modified.include?(@file_path)
+        activate(agent)
+      end
+    end.start
+  end
+end
+
+class MyFileChangeAgent < Sublayer::Agents::Base
+  trigger FileChangeTrigger.new("/path/to/watched_file.txt")
+
+  goal_condition { false }
+
+  check_status {}
+
+  step do
+    puts "File changed!"
+  end
+end
+```
+
+### HTTP Endpoint Trigger Example
+Create a trigger that starts an agent based on an HTTP request.
+
+```ruby
+require 'sinatra'
+
+class HTTPEndpointTrigger < Sublayer::Triggers::Base
+  def initialize(port)
+    @port = port
+  end
+
+  def setup(agent)
+    Thread.new do
+      Sinatra::Application.get('/trigger') do
+        activate(agent)
+        "Agent triggered!"
+      end
+
+      Sinatra::Application.run!
+    end
+  end
+end
+
+class MyHTTPAgent < Sublayer::Agents::Base
+  trigger HTTPEndpointTrigger.new(4567)
+
+  goal_condition { false }
+
+  check_status {}
+
+  step do
+    puts "HTTP endpoint triggered!"
+  end
+end
+```
+
+Run this agent and send a GET request to `http://localhost:4567/trigger` to activate it.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Update 'guides/build-a-custom-trigger.md' to include more examples. While the guide explains building a custom trigger, additional examples would provide clearer understanding and application variety to the users.
  description of file changes: File: docs/guides/build-a-custom-trigger.md
- Add additional code examples showcasing different types of triggers and scenarios where they could be applied, enhancing user comprehension and engagement.