### PR TITLE
Detailed Setup Instructions for Gemini Provider

### DIFF
--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -40,3 +40,56 @@ Usage:
 Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
 Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
 ```
+
+### Gemini Setup
+
+To integrate the Gemini provider, follow these steps:
+
+1. **Environment Setup**:
+   - Ensure your `GEMINI_API_KEY` environment variable is set.
+   
+   ```bash
+   export GEMINI_API_KEY="your-api-key"
+   ```
+
+2. **Initialize Gemini Provider in your application**:
+   
+   ```ruby
+   Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+   Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
+   ```
+
+3. **Example Integration**:
+   - Here’s a basic example of using the Gemini provider:
+   
+   ```ruby
+   require 'sublayer'
+
+   class GeminiIntegrationExample < Sublayer::Generators::Base
+     llm_output_adapter type: :single_string,
+                        name: "example_output",
+                        description: "Example output for demonstration"
+
+     def initialize(input_text)
+       @input_text = input_text
+     end
+
+     def generate
+       super
+     end
+
+     def prompt
+       "Process this text: \\#{@input_text}"
+     end
+   end
+
+   example = GeminiIntegrationExample.new("Hello, Gemini!")
+   puts example.generate
+   ```
+
+4. **Troubleshooting**:
+   - **Invalid API Key**: Ensure the `GEMINI_API_KEY` is correct and active.
+   - **Network Issues**: Check your network connection and any firewalls that might block access.
+   - **Dependencies**: Ensure all required gems and dependencies are installed.
+
+By following these steps, you can effectively integrate and use the Gemini API in your applications.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
The documentation on setting up the Gemini provider is missing critical details, specifically how to integrate the Gemini API using code examples and step-by-step instructions. This can cause confusion among developers who might want to add a custom provider without the API key instructions or code samples.
  description of file changes: Add detailed setup instructions for Gemini provider in the docs/advanced_config.md file. Include sections that explain how to integrate Gemini APIs with examples and troubleshooting tips.