### PR TITLE
Incorporate Practical Usage Examples for Core Concepts

### DIFF
--- a/docs/concepts/actions.md
+++ b/docs/concepts/actions.md
@@ -12,9 +12,7 @@ You can think of actions as similar to tools in other agent frameworks. They enc
 
 ## Action Repository
 
-Curious about what actions are already written and available to use in your
-project? We maintain a repository of community and AI-created Actions that can
-drop right into your project.
+Curious about what actions are already written and available to use in your project? We maintain a repository of community and AI-created Actions that can drop right into your project.
 
 Check it out here: [Sublayer Actions Repository](https://github.com/sublayerapp/sublayer_actions)
 
@@ -28,6 +26,25 @@ Check it out here: [Sublayer Actions Repository](https://github.com/sublayerapp/
 - [RunTestCommandAction](https://github.com/sublayerapp/tddbot/blob/43297c5da9445bd6c8882d5e3876cff5fc6b2650/lib/tddbot/sublayer/actions/run_test_command_action.rb): Runs a test command on the command line returning the output.
 - [SpeechToTextAction](https://github.com/sublayerapp/rails_llm_voice_chat_example/blob/93300f268dde359b58c92a60db4b54d128d9d965/lib/sublayer/actions/speech_to_text_action.rb): Makes an API call to OpenAI's SpeechToText endpoint with audio data and returns text.
 - [TextToSpeechAction](https://github.com/sublayerapp/rails_llm_voice_chat_example/blob/93300f268dde359b58c92a60db4b54d128d9d965/lib/sublayer/actions/text_to_speech_action.rb): Makes an API call to OpenAI's Speech Synthesis endpoint with text and returns audio data.
+
+## Usage Examples
+
+To illustrate how actions work in a practical setting, let's consider using the WriteFileAction.
+
+### WriteFileAction Example
+The `WriteFileAction` writes the specified content into a file at the given path.
+
+#### Example Usage:
+
+```ruby
+# Usage of WriteFileAction
+file_path = "./hello_world.txt"
+file_content = "Hello, World!"
+action = WriteFileAction.new(file_contents: file_content, file_path: file_path)
+action.call
+```
+
+This code creates a text file named 'hello_world.txt' containing the text "Hello, World!".
 
 ## Troubleshooting
 

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -31,6 +31,27 @@ These methods work in concert to create a flexible, event-driven system for auto
 - [RSpecAgent](https://github.com/sublayerapp/sublayer/blob/main/spec/agents/examples/rspec_agent.rb)
   - A Sublayer agent that is triggered any time a test file or an implementation file changes with a goal of making the tests pass. When one of the files changes, the status is checked by running the tests. If the tests are failing, the agent sends the tests and the implementation to an LLM (using a [Sublayer::Generator](/concepts/generators)) to generate a new implementation that should pass the tests.
 
+## Usage Examples
+
+To better understand how an agent works in practice, consider the following example using the RSpecAgent.
+
+### RSpecAgent Example
+This agent monitors changes in specified test and implementation files. Upon detecting a change, it evaluates whether the tests pass and modifies the implementation if necessary.
+
+#### Example Usage:
+
+```ruby
+# Initializing the RSpecAgent
+implementation_file_path = "lib/example_class.rb"
+test_file_path = "spec/example_class_spec.rb"
+agent = RSpecAgent.new(implementation_file_path: implementation_file_path, test_file_path: test_file_path)
+
+# Run the agent
+agent.run
+```
+
+In this scenario, the `RSpecAgent` keeps an eye on the specified files and ensures the implementation meets the tests' requirements, exemplifying a reactive and automated development process.
+
 ## Troubleshooting
 
 For troubleshooting common issues with Agents and more information, please visit our [Troubleshooting Guide](../troubleshooting.md).

--- a/docs/concepts/generators.md
+++ b/docs/concepts/generators.md
@@ -13,9 +13,28 @@ Generators are responsible for generating specific outputs based on input data. 
 
 ### [Examples](https://github.com/sublayerapp/sublayer/tree/main/examples):
 
-* [CodeFromDescriptionGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code\_from\_description\_generator.rb): Generates code based on a description and the technologies used.
-* [DescriptionFromCodeGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/description\_from\_code\_generator.rb): Generates a description of the code passed in to it.
-* [CodeFromBlueprintGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code\_from\_blueprint\_generator.rb): Generates code based on a blueprint, a blueprint description, and a description of the desired code.
+* [CodeFromDescriptionGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code_from_description_generator.rb): Generates code based on a description and the technologies used.
+* [DescriptionFromCodeGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/description_from_code_generator.rb): Generates a description of the code passed in to it.
+* [CodeFromBlueprintGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code_from_blueprint_generator.rb): Generates code based on a blueprint, a blueprint description, and a description of the desired code.
+
+### Usage Examples
+To better understand how Generators work in practice, let's look at a simple example of using the CodeFromDescriptionGenerator.
+
+#### CodeFromDescriptionGenerator Example
+The `CodeFromDescriptionGenerator` can be used to transform a given description into a snippet of code using specified technologies.
+
+**Example Ruby code to use the `CodeFromDescriptionGenerator`:**
+
+```ruby
+# Usage of CodeFromDescriptionGenerator
+description = "A Ruby script that says hello to a user"
+technologies = ["Ruby"]
+generator = CodeFromDescriptionGenerator.new(description: description, technologies: technologies)
+
+puts generator.generate
+```
+
+This example utilizes the generator to produce a simple 'Hello, user!' script in Ruby.
 
 ### Troubleshooting
 

--- a/docs/concepts/triggers.md
+++ b/docs/concepts/triggers.md
@@ -1,0 +1,54 @@
+---
+title: Triggers
+parent: Core Concepts
+nav_order: 4
+---
+
+# Triggers
+
+A trigger is an activation mechanism in an agent that determines when an agent performs its tasks. Triggers can respond to various events or conditions (changes in files, time intervals, or any external inputs) providing flexibility in how and when agents operate. By defining custom triggers, developers can create agents that react dynamically or execute tasks on precise schedules.
+
+## Try making your own trigger:
+
+<iframe src="https://blueprints.sublayer.com/interactive-code-generator/sublayer-triggers" width="100%" height="500px"></iframe>
+
+## Examples:
+
+- [FileChange](https://github.com/sublayerapp/sublayer/blob/main/lib/sublayer/triggers/file_change.rb): Activate agent when a file has changed.
+
+## Usage Examples
+
+To illustrate how triggers can be implemented, here's an example of defining a custom trigger to activate an agent when a specific file is modified.
+
+### FileChange Trigger Example
+Create a custom trigger that activates when a specified file is changed.
+
+```ruby
+class FileChangeTrigger < Sublayer::Triggers::Base
+  def initialize(file_path)
+    @file_path = file_path
+  end
+
+  def setup(agent)
+    Listen.to(File.dirname(@file_path)) do |modified, _added, _removed|
+      if modified.include?(@file_path)
+        activate(agent)
+      end
+    end.start
+  end
+end
+
+class MyFileChangeAgent < Sublayer::Agents::Base
+  trigger FileChangeTrigger.new("/path/to/watched_file.txt")
+
+  goal_condition { false }
+
+  check_status {}
+
+  step do
+    puts "File changed!"
+  end
+end
+```
+
+In this code, the `FileChangeTrigger` listens for changes to a specified file and activates the agent once the file is modified.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Add detailed usage examples for each core concept (Generators, Actions, Agents, Triggers) within their respective documentation pages to provide clarity and enhance understanding of each concept's practical application.
  description of file changes: - docs/concepts/generators.md: Add a section 'Usage Examples' which includes a simple example of creating and using a Generator, similar to the 'CodeFromDescriptionGenerator' described in spec/generators/examples/code_from_description_generator.rb.
- docs/concepts/actions.md: Add a section 'Usage Examples' showcasing the creation of an Action such as the 'WriteFileAction' found in lib/sublayer/cli/commands/generators/example_action_file_manipulation.rb.
- docs/concepts/agents.md: Incorporate a 'Usage Examples' section demonstrating how to set up an Agent, inspired by the examples in spec/agents/examples/rspec_agent.rb.
- docs/concepts/triggers.md: Include a 'Usage Examples' section illustrating how to define a custom Trigger, referencing the examples in lib/sublayer/triggers/file_change.rb.