### PR TITLE
Clarify API Key Configuration

### DIFF
--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -6,6 +6,8 @@ nav_order: 6
 
 After installing Sublayer, you can choose between any of the available LLM providers we support.
 
+For detailed guidance on API key setup, please see our [API Configuration](api-configuration.md) page.
+
 ## OpenAI (Default)
 
 Set your `OPENAI_API_KEY` environment variable. (Visit [OpenAI](https://openai.com/product) to get an API key.)

--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: API Configuration
+nav_order: 7
+---
+
+# API Configuration
+
+This page provides detailed instructions for setting up the API keys required for using various AI providers with Sublayer. Having a dedicated section ensures clarity and prevents confusion from scattered instructions.
+
+## Setting up API keys
+
+### OpenAI (Default)
+
+Set your `OPENAI_API_KEY` environment variable. To obtain an API key, please visit [OpenAI](https://openai.com/product).
+
+Usage:
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+Sublayer.configuration.ai_model = "gpt-4o"
+```
+
+### Anthropic
+
+Set your `ANTHROPIC_API_KEY` environment variable. To obtain an API key, please visit [Anthropic](https://anthropic.com/).
+
+Usage:
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+Sublayer.configuration.ai_model = "claude-3-5-sonnet-20240620"
+```
+
+### Gemini
+
+(Gemini's function calling API is in beta. Not recommended for production use.)
+
+Set your `GEMINI_API_KEY` environment variable. To obtain an API key, please visit [Google AI Studio](https://ai.google.dev/).
+
+Usage:
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+Sublayer.configuration.ai_model = "gemini-1.5-pro"
+```

--- a/docs/guides/build-a-custom-trigger.md
+++ b/docs/guides/build-a-custom-trigger.md
@@ -67,6 +67,8 @@ bundle install
 
 ## Additional Examples of Custom Triggers
 
+Make sure to set up your API keys correctly as outlined in the [API Configuration](../api-configuration.md) if you are working with any custom functionality requiring external services.
+
 ### File Change Trigger Example
 Create a custom trigger that activates when a specific file is changed.
 


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
There seems to be some confusion regarding API key configuration as it appears in multiple files both in the libraries and configuration docs. It would be prudent to have a consolidated section explaining the API configuration requirements in a separate file or section to prevent any confusion.
  description of file changes: - Create 'docs/api-configuration.md' to have a dedicated page for API key setup and configuration.
- Reference this new documentation page in 'docs/advanced_config.md' and the relevant guides.