### PR TITLE
Expand Provider Documentation with Examples

### DIFF
--- a/docs/concepts/generators.md
+++ b/docs/concepts/generators.md
@@ -3,9 +3,37 @@ title: Generators
 parent: Core Concepts
 nav_order: 1
 ---
+
 # Generators
 
 Generators are responsible for generating specific outputs based on input data. They focus on a single generation task and do not perform any actions or complex decision-making. Generators are the building blocks of the Sublayer framework.
+
+### Using AI Providers with Generators
+
+Sublayer supports multiple AI providers, allowing you to select the best one for your needs. Here's how you can configure them:
+
+#### OpenAI
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+Sublayer.configuration.ai_model = "gpt-4o"
+```
+
+#### Gemini
+
+Note: Gemini is currently in beta and may not be suitable for production use.
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+Sublayer.configuration.ai_model = "gemini-1.5-pro"
+```
+
+#### Claude
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+Sublayer.configuration.ai_model = "claude-3-5-sonnet-20240620"
+```
 
 ### Try making your own generator:
 
@@ -14,8 +42,8 @@ Generators are responsible for generating specific outputs based on input data. 
 ### [Examples](https://github.com/sublayerapp/sublayer/tree/main/examples):
 
 * [CodeFromDescriptionGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code\_from\_description\_generator.rb): Generates code based on a description and the technologies used.
-* [DescriptionFromCodeGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/description\_from\_code\_generator.rb): Generates a description of the code passed in to it.
-* [CodeFromBlueprintGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code\_from\_blueprint\_generator.rb): Generates code based on a blueprint, a blueprint description, and a description of the desired code.
+* [DescriptionFromCodeGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/description_from_code_generator.rb): Generates a description of the code passed in to it.
+* [CodeFromBlueprintGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code_from_blueprint_generator.rb): Generates code based on a blueprint, a blueprint description, and a description of the desired code.
 
 ### Troubleshooting
 

--- a/docs/guides/configuring-ai-providers.md
+++ b/docs/guides/configuring-ai-providers.md
@@ -1,0 +1,88 @@
+---
+title: Configuring AI Providers
+parent: Guides
+---
+# Configuring AI Providers
+
+Sublayer supports multiple AI providers. This guide walks you through setting up and using OpenAI, Gemini, and Claude with Sublayer. Each provider has its unique features and setup requirements.
+
+## OpenAI
+
+OpenAI is the default provider. To configure Sublayer to use OpenAI, ensure your environment is set up with the OpenAI API key.
+
+```shell
+export OPENAI_API_KEY="your-api-key"
+```
+
+Then configure Sublayer:
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+Sublayer.configuration.ai_model = "gpt-4o"
+```
+
+### Example Usage
+
+```ruby
+require 'sublayer'
+
+class YourGenerator < Sublayer::Generators::Base
+  # Your generator logic here
+end
+```
+
+## Gemini
+
+Gemini is still in beta, with function calling features in experimental stages. Be cautious when using it for production.
+
+Set your API key:
+
+```shell
+export GEMINI_API_KEY="your-api-key"
+```
+
+Configure Sublayer:
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+Sublayer.configuration.ai_model = "gemini-1.5-pro"
+```
+
+### Example Usage
+
+```ruby
+require 'sublayer'
+
+class GeminiGenerator < Sublayer::Generators::Base
+  # Your generator logic tailored for Gemini
+end
+```
+
+## Claude
+
+Claude offers models tailored for different tasks. Set up your environment with the Claude API key:
+
+```shell
+export ANTHROPIC_API_KEY="your-api-key"
+```
+
+Configure Sublayer:
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+Sublayer.configuration.ai_model = "claude-3-5-sonnet-20240620"
+```
+
+### Example Usage
+
+```ruby
+require 'sublayer'
+
+class ClaudeGenerator < Sublayer::Generators::Base
+  # Your generator logic designed for Claude
+end
+```
+
+## Conclusion
+
+Selecting the right AI provider depends on your project requirements and the specific features of each LLM. By following the steps above, you can easily configure and switch between different providers in Sublayer.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -9,6 +9,10 @@ We're always looking for more ideas for guides. If you have an idea for a guide,
 
 ## List of Guides
 
+### [Configuring AI Providers]({% link docs/guides/configuring-ai-providers.md %})
+
+A guide detailing how to configure and utilize different AI providers supported by Sublayer, including OpenAI, Gemini, and Claude.
+
 ### [Rails Voice Chat with LLM]({% link docs/guides/voice-chat.md %})
 
 A Ruby on Rails app that uses OpenAI's Speech to Text and Text to Speech APIs to enable voice chatting with an LLM.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -10,7 +10,7 @@ You can think of a Sublayer Generator as an object that takes some string inputs
 
 In this example, we'll create a simple generator that takes a description of code and the technologies to use and generates code using an LLM like GPT-4.
 
-***
+---
 
 ### Step 1 - Installation
 
@@ -34,7 +34,23 @@ Set your OpenAI API key as an environment variable:
 export OPENAI_API_KEY="your-api-key"
 ```
 
-Don't have a key? Visit [OpenAI](https://openai.com/product) to get one.
+Don't have an OpenAI API key? Visit [OpenAI](https://openai.com/product) to get one.
+
+For Gemini users, set your Gemini API key:
+
+```shell
+export GEMINI_API_KEY="your-api-key"
+```
+
+Visit [Google AI Studio](https://ai.google.dev/) to get a Gemini API key.
+
+For Claude users, set your Claude API key:
+
+```shell
+export ANTHROPIC_API_KEY="your-api-key"
+```
+
+Visit [Anthropic](https://anthropic.com/) to get a Claude API key.
 
 ### Step 3a - Create a Generator
 
@@ -65,11 +81,11 @@ module Sublayer
 
       def prompt
         <<-PROMPT
-          You are an expert programmer in \#{@technologies.join(", ")}.
+          You are an expert programmer in \\#{@technologies.join(", ")}.
 
-          You are tasked with writing code using the following technologies: \#{@technologies.join(", ")}.
+          You are tasked with writing code using the following technologies: \\#{@technologies.join(", ")}.
 
-          The description of the task is \#{@description}
+          The description of the task is \\#{@description}
 
           Take a deep breath and think step by step before you start coding.
         PROMPT
@@ -91,7 +107,7 @@ Try generating your own generator with our interactive code generator below:
 
 Require the Sublayer gem and your generator and call `generate`!
 
-Here's an example of how you might use the \`CodeFromDescriptionGenerator\` above:
+Here's an example of how you might use the `CodeFromDescriptionGenerator` above:
 
 ```ruby
 # ./example.rb
@@ -102,6 +118,37 @@ require './code_from_description_generator'
 generator = Sublayer::Generators::CodeFromDescriptionGenerator.new(description: 'a function that returns the first 10 happy numbers', technologies: ['ruby'])
 
 puts generator.generate
+```
+
+### Using Different Providers
+
+You can also configure Sublayer to use different LLM providers:
+
+#### OpenAI
+
+Set it as the AI provider (it's the default):
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+Sublayer.configuration.ai_model = "gpt-4o"
+```
+
+#### Gemini (Unstable)
+
+Set it as the AI provider:
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+Sublayer.configuration.ai_model = "gemini-1.5-pro"
+```
+
+#### Claude
+
+Set it as the AI provider:
+
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+Sublayer.configuration.ai_model = "claude-3-5-sonnet-20240620"
 ```
 
 ### Next Steps


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Add detailed descriptions and usage examples for each provider supported by Sublayer, including OpenAI, Gemini, and Claude. Given the complexity and varying functionality of these providers, it will help users to clearly understand how they can integrate and utilize these providers with the framework.
  description of file changes: In `docs/quick_start.md`, `docs/concepts/generators.md`, `docs/guides/index.md`, add sections that detail how to configure and use each of the supported AI providers. Include examples and explanations of configuration settings specific to each provider. Ensure there's a standardized format for these sections to maintain consistency.