### PR TITLE
Add Practical Examples for Using Generators

### DIFF
--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -40,3 +40,38 @@ Usage:
 Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
 Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
 ```
+
+## Custom Generator Setups
+
+### Creating Custom Generators
+
+Custom generators can be tailored for specific needs by modifying the generator's logic, input options, and output formatting to fit your unique data pipelines or application structures.
+
+### Utilizing Different Providers
+
+Sublayer supports a range of providers. You can switch between them or use multiple providers within the same application, depending on the needs of your solution.
+
+### Handling Edge Cases
+
+It's crucial to anticipate and handle edge cases in your generator logic. Implement appropriate error handling and validation to ensure robustness and reliability.
+
+### Example: Integrating a New Provider
+
+Here’s how you can integrate a hypothetical new provider into your setup:
+
+```ruby
+module Sublayer
+  module Providers
+    class NewProvider
+      def self.call(prompt:, output_adapter:)
+        # Integration logic for the new provider
+      end
+    end
+  end
+end
+
+Sublayer.configuration.ai_provider = Sublayer::Providers::NewProvider
+Sublayer.configuration.ai_model = "new-model-1.0"
+```
+
+By understanding and utilizing the advanced configurations possible with Sublayer, you can maximize the efficiency and effectiveness of your AI solutions.

--- a/docs/concepts/generators.md
+++ b/docs/concepts/generators.md
@@ -17,6 +17,66 @@ Generators are responsible for generating specific outputs based on input data. 
 * [DescriptionFromCodeGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/description\_from\_code\_generator.rb): Generates a description of the code passed in to it.
 * [CodeFromBlueprintGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code\_from\_blueprint\_generator.rb): Generates code based on a blueprint, a blueprint description, and a description of the desired code.
 
+### Real-World Examples and Pseudo Scenarios
+
+#### 1. Generating a RESTful API
+
+This example demonstrates building a simple CRUD application using Generators to scaffold the basic API structure.
+
+```ruby
+# Ruby
+require 'sublayer'
+
+class ApiGenerator < Sublayer::Generators::Base
+  llm_output_adapter type: :single_string, name: "api_code", description: "The generated code for a simple RESTful API"
+
+  def initialize(description:, technologies:)
+    @description = description
+    @technologies = technologies
+  end
+
+  def generate
+    super
+  end
+
+  def prompt
+    <<-PROMPT
+    Generate a RESTful API for a resource called 'posts', including CRUD operations (Create, Read, Update, Delete).
+    Technologies to use: #{@technologies.join(", ")}
+    PROMPT
+  end
+end
+```
+
+#### 2. Creating a Data Analysis Script
+
+Illustrates using a Generator to create a script that performs basic data analysis based on user requirements.
+
+```ruby
+# Ruby
+require 'sublayer'
+
+class DataAnalysisGenerator < Sublayer::Generators::Base
+  llm_output_adapter type: :single_string, name: "analysis_code", description: "Generated code for analyzing data"
+
+  def initialize(description:, technologies:)
+    @description = description
+    @technologies = technologies
+  end
+
+  def generate
+    super
+  end
+
+  def prompt
+    <<-PROMPT
+    Write a script to analyze sales data, producing summary statistics and visualizations.
+    Technologies: #{@technologies.join(", ")}
+    PROMPT
+  end
+end
+```
+
 ### Troubleshooting
 
 If you encounter issues while working with Generators, please refer to the [Troubleshooting Guide](../troubleshooting.md) for common error scenarios and solutions.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
The documentation should integrate detailed examples showcasing the usage of Generators in different scenarios. This inclusion will help users quickly comprehend how to implement and use Generators for their projects, enhancing onboarding and reducing learning curves.
  description of file changes: - **Update `docs/concepts/generators.md`**: Append real-world examples or pseudo scenarios that demonstrate how to set up and use Generators efficiently. Include code snippets and expected outcomes to provide a comprehensive understanding.
- **Create new sections for custom Generator setups**: Under the existing Generators page or other appropriate documentation pages, add sections that explore creating custom setups, utilizing different providers, or dealing with edge cases.