### PR TITLE
CLI Setup Guide

### DIFF
--- a/docs/guides/cli_setup.md
+++ b/docs/guides/cli_setup.md
@@ -1,0 +1,64 @@
+---
+layout: default
+title: CLI Setup
+parent: Guides
+nav_order: 4
+---
+
+# Setting up the Sublayer CLI
+
+This guide will walk you through setting up and using the Sublayer CLI tool to initialize a new CLI project.
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+- **Ruby** (version 2.6 or later)
+- **Sublayer gem**
+
+Install the Sublayer gem:
+
+```bash
+$ gem install sublayer
+```
+
+## Initializing a New Project
+
+To start a new CLI project with Sublayer:
+
+1. Create a new directory for your project:
+   ```bash
+   $ mkdir my_new_cli_project
+   $ cd my_new_cli_project
+   ```
+
+2. Generate a new project:
+   ```bash
+   $ sublayer new your_project_name --template cli
+   ```
+
+   This command sets up a new CLI project with the necessary files and dependencies.
+
+## Basic Usage
+
+Now that you have set up a new project, you can start creating commands and actions:
+
+- **Create a Command**: Generate a command that your CLI tool will support.
+  ```bash
+  $ sublayer generate:command ExampleCommand
+  ```
+
+- **Create an Action**: Define actions that dictate the business logic of your CLI.
+  ```bash
+  $ sublayer generate:action MyAction
+  ```
+
+## Running Your CLI Tool
+
+To run your CLI application:
+
+```bash
+$ bin/your_project_name example_command
+```
+
+This will execute the `example_command` within your CLI application.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -31,3 +31,11 @@ A guide on the recommended way to set up and run LLMs locally to interface with 
 * Learn how to set up [llamafile](https://github.com/Mozilla-Ocho/llamafile)
 * Learn which models we recommend for local use
 * Learn how to point Sublayer to your locally running server
+
+### [CLI Setup]({% link docs/guides/cli_setup.md %})
+
+A comprehensive guide to setting up and using the Sublayer CLI.
+
+* Learn how to initialize a new CLI project using Sublayer
+* Explore command and action generation
+* Understand basic CLI tool execution


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Add a comprehensive guide on setting up and using the Sublayer CLI.
  description of file changes: Create a new file at `docs/guides/cli_setup.md` with detailed steps on initializing a new CLI project using the Sublayer framework, including command usage and examples. Reference this new guide in the `docs/guides/index.md` under the list of guides to direct users where to go for CLI setup instructions.