### PR TITLE
Guidance on Creating Custom AI Model Providers

### DIFF
--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -40,3 +40,42 @@ Usage:
 Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
 Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
 ```
+
+## Creating Custom AI Model Providers
+
+To extend Sublayer to support additional AI models beyond the built-in ones, you can create custom providers. Follow the steps below to implement custom model support:
+
+### Step 1: Define Your Custom Provider Class
+
+In your Sublayer project, create a new Ruby file, and define a class within `Sublayer::Providers` module. The class should have a `.call` method that takes `prompt:` and `output_adapter:` as keyword arguments:
+
+```ruby
+module Sublayer
+  module Providers
+    class MyCustomProvider
+      def self.call(prompt:, output_adapter:)
+        # Implement API interaction here
+      end
+    end
+  end
+end
+```
+
+### Step 2: Configure Your Provider
+
+After defining your provider class, configure Sublayer to use it. Set the provider and model in your configuration file:
+
+```ruby
+Sublayer.configure do |config|
+  config.ai_provider = Sublayer::Providers::MyCustomProvider
+  config.ai_model = "your-model-name"
+end
+```
+
+### Step 3: Implement the API Call
+
+Within the `.call` method, implement logic to interact with the specific API of the AI model. You may want to refer to existing provider implementations in `lib/sublayer/providers/open_ai.rb` or `spec/providers/open_ai_spec.rb` for examples.
+
+### Example
+
+For guidance, look at `lib/sublayer/providers/open_ai.rb` and `spec/providers/open_ai_spec.rb` to understand how to structure your API call and handle responses.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Update documentation to include detailed information on how to create custom AI model providers in Sublayer. This is essential as users need guidance on extending Sublayer to support models beyond the built-in ones like OpenAI, Claude, and Gemini. Provide code samples and outline steps clearly to facilitate user implementation.
  description of file changes: File: docs/advanced_config.md
Add a new section titled 'Creating Custom AI Model Providers'. Include detailed instructions on how users can implement support for additional AI models by subclassing and augmenting the existing provider pattern. Use examples given in files such as lib/sublayer/providers/open_ai.rb and spec/providers/open_ai_spec.rb to illustrate the implementation process. Provide snippets to show setup and configuration.