### PR TITLE
Extend Custom Component Documentation

### DIFF
--- a/docs/custom_components/index.md
+++ b/docs/custom_components/index.md
@@ -8,3 +8,35 @@ The Sublayer framework is designed to be extensible and customizable. Beyond jus
 
 * [Output Adapters]({% link docs/custom_components/output-adapters.md %})
 * [Triggers]({% link docs/custom_components/triggers.md %})
+
+## Getting Started with Custom Adapters
+
+Creating custom adapters allows you to define how the outputs from your Generators and other components are handled. This can be particularly useful if you need the output to be formatted or processed in a specific way.
+
+### Building Custom Output Adapters and Providers
+
+To build custom output adapters and providers, you can follow these steps:
+
+1. **Understand the Interface:** Study the interface defined in `lib/sublayer/components/output_adapters`. Your adapter should implement the required methods.
+2. **Use Existing Snippets:** Use snippets from `spec/components/output_adapters` to guide your development and ensure compatibility with the rest of the Sublayer framework.
+3. **Develop the Adapter:** Create your adapter implementing necessary methods such as `initialize`, `properties`, and any additional methods needed for your processing logic.
+4. **Test and Validate:** Compile your adapter and test it using the relevant specs to check its functionality.
+
+### Example: Creating an Example Adapter
+
+This example demonstrates how to create a simple adapter:
+
+```ruby
+class MyOutputAdapter < Sublayer::Components::OutputAdapters::Base
+  attr_reader :name, :description
+
+  def initialize(name:, description:)
+    @name = name
+    @description = description
+  end
+
+  # Define more methods as needed
+end
+```
+
+Refer to the provided specs and existing adapter implementations for more detailed examples.

--- a/docs/custom_components/output-adapters.md
+++ b/docs/custom_components/output-adapters.md
@@ -39,11 +39,19 @@ class MyGenerator < Sublayer::Generators::Base
 end
 ```
 
-### Examples
+### Examples of Custom Adapters
 
-Below are links to the built-in output adapters in Sublayer and are fully tested against example generators. You can use these as a reference when building your own output adapters.
+Here are some more advanced examples of how you can extend an adapter:
 
-- [Single String](https://github.com/sublayerapp/sublayer/blob/e57d4e44117cec6e6c0f750d53b499df7bc66ca1/lib/sublayer/components/output_adapters/single_string.rb)
-- [List of Strings](https://github.com/sublayerapp/sublayer/blob/e57d4e44117cec6e6c0f750d53b499df7bc66ca1/lib/sublayer/components/output_adapters/list_of_strings.rb)
-- [String Selection from List](https://github.com/sublayerapp/sublayer/blob/e57d4e44117cec6e6c0f750d53b499df7bc66ca1/lib/sublayer/components/output_adapters/string_selection_from_list.rb)
-- [Named Strings](https://github.com/sublayerapp/sublayer/blob/e57d4e44117cec6e6c0f750d53b499df7bc66ca1/lib/sublayer/components/output_adapters/named_strings.rb)
+- **Mapping Outputs to Custom Data Structures:** Use custom logic in `materialize_result` to map complex LLM responses directly into domain-specific data structures.
+
+- **Dynamic Properties:** Implement `load_instance_data` to dynamically set up properties based on runtime data provided to the generator.
+
+## Example Output Adapter
+
+Below are links to built-in output adapters in Sublayer, all fully tested with example generators. Use these as references:
+
+- [Single String](https://github.com/sublayerapp/sublayer/blob/main/lib/sublayer/components/output_adapters/single_string.rb): Captures single string outputs.
+- [List of Strings](https://github.com/sublayerapp/sublayer/blob/main/lib/sublayer/components/output_adapters/list_of_strings.rb): Handles multiple string outputs.
+- [String Selection from List](https://github.com/sublayerapp/sublayer/blob/main/lib/sublayer/components/output_adapters/string_selection_from_list.rb): Selects from enumerated options.
+- [Named Strings](https://github.com/sublayerapp/sublayer/blob/main/lib/sublayer/components/output_adapters/named_strings.rb): Structures LLM output with named attributes.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Enhance documentation on extending capacity with Custom Components. The current documentation in 'docs/custom_components/index.md' and the associated detail pages provide some insight but lack structured examples for developing custom output adapters and providers. Expanding these sections could significantly enhance users' capability to customize and extend their frameworks.
  description of file changes: 1. Update 'docs/custom_components/index.md':
   - Include a section "Getting Started with Custom Adapters" detailing how to build custom output adapters and providers, based on `lib/sublayer/components/output_adapters`
   - Use snippets directly from existing specs, like those in `spec/components/output_adapters`, for clarity.
   - Illustrate a step-by-step walkthrough for an example adapter.
2. Similarly, update 'docs/custom_components/output-adapters.md':
   - Add new examples and explanations for each segment with links back to reference code.