### PR TITLE
Add Claude Provider Instructions

### DIFF
--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -31,3 +31,24 @@ A guide on the recommended way to set up and run LLMs locally to interface with 
 * Learn how to set up [llamafile](https://github.com/Mozilla-Ocho/llamafile)
 * Learn which models we recommend for local use
 * Learn how to point Sublayer to your locally running server
+
+### [Run Llama3.1 with Ollama]({% link docs/guides/running-local-llama31-with-ollama.md %})
+
+Learn how to run Llama3.1 models with the Ollama interface locally.
+
+* Setting up your environment to run Llama3.1 locally.
+* Integration with Sublayer as a provider.
+
+### [Build a Custom Agent Trigger]({% link docs/guides/build-a-custom-trigger.md %})
+
+Learn how to build custom triggers for agents in Sublayer.
+
+* Create a simple agent with a custom trigger.
+* Examples of custom triggers for different use-cases.
+
+### [Choose your AI Model]({% link docs/guides/choose-your-ai-model.md %})
+
+Understand how to configure different AI models with Sublayer including OpenAI, Gemini, and Claude.
+
+* Setting your API keys and configuring your model of choice.
+* Walkthrough for integrating Claude as a provider.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Incorporate missing provider instructions for Claude into the documentation section 'Choose your AI Model'. Currently, we only have OpenAI and Gemini documented. This will help users who wish to use Claude as a provider.
  description of file changes: In the file 'docs/guides/index.md', under the section 'Choose your AI Model', add a subsection for 'Claude' that describes how to configure Sublayer to use Claude as a provider, including setting up the API key and configuring the model.