### PR TITLE
Create a CLI Commands Guide

### DIFF
--- a/docs/guides/cli_commands.md
+++ b/docs/guides/cli_commands.md
@@ -1,0 +1,68 @@
+---
+title: Sublayer CLI Commands
+description: A guide to all CLI commands available in Sublayer
+date: 2024-01-01
+parent: Guides
+---
+
+# Sublayer CLI Commands
+
+Sublayer provides a variety of Command Line Interface (CLI) commands to interact with the framework efficiently. This guide covers all available CLI commands and how you can extend them.
+
+## Available Commands
+
+### `generate:generator`
+
+Generates a new Sublayer Generator subclass for your project.
+
+**Usage:**
+```
+sublayer generate:generator --description "<Description>"
+```
+
+- `--description`: Detail what the generator will do.
+
+### `generate:agent`
+
+Generates a new Sublayer Agent subclass for your project.
+
+**Usage:**
+```
+sublayer generate:agent --description "<Description>"
+```
+
+- `--description`: Describe the agent's functionality.
+
+### `generate:action`
+
+Generates a new Sublayer Action subclass for your project.
+
+**Usage:**
+```
+sublayer generate:action --description "<Description>"
+```
+
+- `--description`: Outline what the action should perform.
+
+## Extending CLI Functionalities
+
+You can expand the CLI's capabilities by creating custom commands using the Sublayer framework.
+
+### Custom Command Example
+
+To create a custom command, utilize the Thor library which Sublayer is using under the hood. Here is a basic example:
+
+```ruby
+module MyProject
+  class CLI < Thor
+    desc "say_hello NAME", "Say hello to a user"
+    def say_hello(name)
+      puts "Hello, \\#{name}!"
+    end
+  end
+end
+```
+
+Integrate your custom command with other Sublayer components like Actions and Generators to achieve more complex tasks in your projects.
+
+For more details on customizing commands, refer to the Ruby [Thor documentation](https://github.com/erikhuda/thor).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -31,3 +31,20 @@ A guide on the recommended way to set up and run LLMs locally to interface with 
 * Learn how to set up [llamafile](https://github.com/Mozilla-Ocho/llamafile)
 * Learn which models we recommend for local use
 * Learn how to point Sublayer to your locally running server
+
+### [Run Llama3.1 with Ollama]({% link docs/guides/running-local-llama31-with-ollama.md %})
+
+A guide for running the Llama3.1 model locally using Ollama.
+
+* Learn how to install and use Ollama
+* Instructions on running the Llama3.1 model
+
+### [Build a Custom Agent Trigger]({% link docs/guides/build-a-custom-trigger.md %})
+
+Learn how to build a custom time-based trigger using the Sublayer framework.
+
+### [Sublayer CLI Commands]({% link docs/guides/cli_commands.md %})
+
+A complete list and guide for using Sublayer's CLI commands.
+
+This includes sections on extending CLI functionalities with custom commands such as `generate:action` and `new_project`.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Introduce a new documentation page dedicated to Sublayer's CLI commands. Although CLI commands are mentioned in the code and some documentation, a comprehensive guide is missing. This inclusion would offer users a centralized resource to understand how to effectively use and extend CLI capabilities in Sublayer.
  description of file changes: Files: docs/guides/index.md, Introduce a new file docs/guides/cli_commands.md\n- Create a new page under guides that lists and explains all available CLI commands, their options, and examples of how to use them.\n- Incorporate sections on extending CLI functionalities with custom commands, referencing examples such as `generate:action` and `new_project`.