### PR TITLE
Add Dependency Conflict Resolution Guide

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -11,3 +11,4 @@ Browse the links below to go more in depth into each of these concepts:
 * [Generators]({% link docs/concepts/generators.md %})
 * [Actions]({% link docs/concepts/actions.md %})
 * [Agents]({% link docs/concepts/agents.md %})
+* [Troubleshooting]({% link docs/troubleshooting.md %})

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -16,7 +16,7 @@ This document provides common error scenarios and troubleshooting tips to assist
 
 ### 2. Dependency Conflicts
 **Problem:** Conflicts between gem dependencies leading to bundling failures.  
-**Solution:** Check the `Gemfile.lock` for dependency versions and resolve conflicts by updating or downgrading gems as necessary.
+**Solution:** Check the `Gemfile.lock` for dependency versions and resolve conflicts by updating or downgrading gems as necessary. Some common scenarios include version mismatches or incompatible versions of shared dependencies. It's crucial to ensure that all dependencies are resolved to compatible versions. Review any output from `bundle install` for indicators of where conflicts may lie and consider using a tool like `Bundler Doctor` to aid in diagnosing these issues.
 
 ### 3. Network Issues
 **Problem:** Network-related errors when calling external APIs.  


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
The current documentation doesn't explain how to handle dependency conflicts, an issue that many developers might face when integrating the Sublayer gem into their existing projects. This leads to unnecessary troubleshooting and delays.
  description of file changes: Add a new section in 'Troubleshooting' (docs/troubleshooting.md) titled 'Handling Dependency Conflicts' with details on how developers can address issues with conflicting dependencies, especially during bundling. Include common scenarios and suggested resolutions.