### PR TITLE
Complete Missing Details in Custom Components Documentation

### DIFF
--- a/docs/custom_components/index.md
+++ b/docs/custom_components/index.md
@@ -1,10 +1,21 @@
 ---
 title: Custom Components
 nav_order: 4
+has_children: true
 ---
 # Custom Components
 
 The Sublayer framework is designed to be extensible and customizable. Beyond just building your own Generators, Actions, and Agents, you can also create your own custom Output Adapters for your Generators, Triggers for your Agents, and Providers for any custom model you're working with.
 
-* [Output Adapters]({% link docs/custom_components/output-adapters.md %})
-* [Triggers]({% link docs/custom_components/triggers.md %})
+## Table of Contents
+
+- [Output Adapters](#output-adapters)
+- [Triggers](#triggers)
+
+### [Output Adapters]({% link docs/custom_components/output-adapters.md %})
+
+Custom Output Adapters allow you to define the structure and format of the AI-generated output. They serve as a bridge between the raw AI responses and the structured data your application expects.
+
+### [Triggers]({% link docs/custom_components/triggers.md %})
+
+Triggers determine when an agent performs its tasks, giving you flexibility in how agents react to various conditions or events.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Update 'Custom Components' documentation to include missing details about creating and using Triggers and Output Adapters. This will ensure users have a complete guide for building these components according to their specific needs.
  description of file changes: Update `docs/custom_components/index.md`:
1. Ensure the section headers and links correctly correspond to all component types.
2. Provide missing example code for creating both custom Triggers and Output Adapters.
3. Update external links to correct targets if any inconsistencies are found.