### PR TITLE
Guide to Creating and Using Agents

### DIFF
--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -1,35 +1,80 @@
 ---
 title: Agents
+description: A detailed guide on creating and using agents within the Sublayer framework, including lifecycle and trigger explanations.
 parent: Core Concepts
 nav_order: 3
 ---
 # Agents
 
-Think of Sublayer Agents as your personal assistants, always ready to help with repetitive tasks or respond to changes in your environment. These agents can assist with a wide range of activities, from coding to data processing to system monitoring and beyond. You create an agent by defining four key aspects: what should wake it up (triggers), what it's trying to achieve (goal condition), how it checks its progress (check status), and what it actually does (step).
+Think of Sublayer Agents as your personal assistants, always ready to help with repetitive tasks or respond to changes in your environment. These agents can assist with a wide range of activities, from coding to data processing to system monitoring and beyond.
 
-Triggers could be things like file changes, incoming data, time-based events, or even manual calls while the goal might be completing a data analysis or updating a system. The agent will keep checking its status and taking steps until it reaches its goal. It's like having a tireless helper that knows exactly when to jump in and what to do, making a variety of processes more efficient and responsive to change. Whether you're automating workflows, monitoring systems, or processing data, Sublayer Agents provide a flexible, event-driven approach to tackling complex and repetitive tasks.
+## Guide to Writing and Utilizing Agents
 
-## Writing an Agent
+### Agent Lifecycle
 
-Sublayer Agents are autonomous units of execution designed to perform specific tasks or monitor systems. They are built on top of the `Sublayer::Agents::Base` class and utilize a Domain Specific Language (DSL) for defining their behavior.
+Sublayer Agents operate autonomously, similar to how a personal assistant might work for you. They can handle various tasks, such as monitoring systems, processing data, automating workflows, and more. You create an agent by defining four key aspects:
 
-The DSL consists of four primary methods:
+- **Triggers**: Specifies events that wake the agent up, such as file changes, incoming data, time-based events, or a manual call.
+- **Goal Condition**: This is the ultimate objective the agent is trying to achieve, like completing a data analysis or updating a system.
+- **Check Status**: This is how the agent checks its progress toward the goal.
+- **Step**: This is the actual work or task that the agent performs.
 
-- `trigger`: Specifies events that activate the agent (e.g., file changes, time-based events, webhooks, etc.)
-- `goal_condition`: Defines the criteria for task completion
-- `check_status`: Evaluates the current state of the task
-- `step`: Implements the actual logic to be executed
+The agent life cycle starts with an event triggering the agent, followed by the agent performing the steps until the goal condition is satisfied. The agent will keep checking its status and taking steps until it completes its task, making processes more efficient and responsive.
 
-These methods work in concert to create a flexible, event-driven system for automating complex workflows and responding to changes in various environments.
+### Example: RSpecAgent
+
+Here's an example of a Sublayer agent, the RSpecAgent, which highlights these aspects:
+
+- **Trigger**: The RSpecAgent is designed to activate when a test file or implementation file changes.
+- **Goal**: Its goal is ensuring the tests pass.
+- **Check Status**: The agent runs the tests to verify if they succeed.
+- **Step**: If tests are failing, the agent sends both the tests and the implementation to a language model to generate a new implementation intended to pass the tests.
+
+```ruby
+class RSpecAgent < Sublayer::Agents::Base
+  def initialize(implementation_file_path:, test_file_path:)
+    @implementation_file_path = implementation_file_path
+    @test_file_path = test_file_path
+    @tests_passing = false
+  end
+
+  trigger_on_files_changed { [@implementation_file_path, @test_file_path] }
+
+  goal_condition { @tests_passing == true }
+
+  check_status do
+    stdout, stderr, status = Sublayer::Actions::RunTestCommandAction.new(
+      test_command: "rspec #{@test_file_path}"
+    ).call
+
+    @test_output = stdout
+    @tests_passing = (status.exitstatus == 0)
+  end
+
+  step do
+    modified_implementation = Sublayer::Generators::ModifiedImplementationToPassTestsGenerator.new(
+      implementation_file_contents: File.read(@implementation_file_path),
+      test_file_contents: File.read(@test_file_path),
+      test_output: @test_output
+    ).generate
+
+    Sublayer::Actions::WriteFileAction.new(
+      file_contents: modified_implementation,
+      file_path: @implementation_file_path
+    ).call
+  end
+end
+```
+
+### How Triggers Work
+
+Triggers activate agents based on various conditions. For instance, a trigger could be a change in a file, a particular time interval, or a webhook event. Once activated, the agent evaluates its status and performs tasks until the defined goal is achieved.
+
+Understanding and using triggers are essential for developing efficient agents that respond dynamically to changes or schedule-based activities.
 
 ## Try generating your own agent:
 
 <iframe src="https://blueprints.sublayer.com/interactive-code-generator/sublayer-agents" width="100%" height="500px"></iframe>
-
-## Examples:
-
-- [RSpecAgent](https://github.com/sublayerapp/sublayer/blob/main/spec/agents/examples/rspec_agent.rb)
-  - A Sublayer agent that is triggered any time a test file or an implementation file changes with a goal of making the tests pass. When one of the files changes, the status is checked by running the tests. If the tests are failing, the agent sends the tests and the implementation to an LLM (using a [Sublayer::Generator](/concepts/generators)) to generate a new implementation that should pass the tests.
 
 ## Troubleshooting
 

--- a/docs/custom_components/triggers.md
+++ b/docs/custom_components/triggers.md
@@ -1,17 +1,80 @@
 ---
 title: Agent Triggers
+description: Explanation on building custom triggers for agents, with examples and use cases.
 parent: Custom Components
 nav_order: 2
 ---
-
 # Custom Agent Triggers
 
-A trigger is an activation mechanism in an agent that determines when an agent performs its tasks. Triggers can respond to various events or conditions (changes in files, time intervals, or any external inputs) providing flexibility in how and when agents operate. By defining custom triggers, developers can create agents that react dynamically or execute tasks on precise schedules.
+Triggers in Sublayer Agents are mechanisms that determine when an agent should begin its tasks. They can be based on file changes, time intervals, or any predefined events, allowing developers to create a wide array of responsive and dynamic agent behaviors.
+
+## Creating Triggers
+
+To create a trigger, you need to define when and how the agent should be activated. Triggers are powerful because they dictate the agent's responsiveness to certain conditions or events. Here's the blueprint for a basic Trigger:
+
+```ruby
+module Sublayer
+  module Triggers
+    class Base
+      def initialize(&block)
+        @block = block
+      end
+
+      def setup(agent)
+        raise NotImplementedError, "Subclasses must implement setup method"
+      end
+
+      def activate(agent)
+        agent.send(:take_step)
+      end
+    end
+  end
+end
+```
+
+### FileChange Trigger Example
+
+```ruby
+class FileChangeTrigger < Sublayer::Triggers::Base
+  def initialize(file_path)
+    @file_path = file_path
+  end
+
+  def setup(agent)
+    Listen.to(File.dirname(@file_path)) do |modified, added, removed|
+      if modified.include?(@file_path)
+        activate(agent)
+      end
+    end.start
+  end
+end
+
+class MyFileChangeAgent < Sublayer::Agents::Base
+  trigger FileChangeTrigger.new("/path/to/watched_file.txt")
+
+  goal_condition { false }
+
+  check_status {}
+
+  step do
+    puts "File changed!"
+  end
+end
+```
+
+## Examples of Triggers
+
+- **FileChange**: Activates an agent when a file change is detected, useful for scenarios like automatic test runs or content refreshes.
+- **TimeInterval**: Triggers an agent at specified intervals, allowing for periodic tasks or checks.
 
 ## Try making your own trigger:
 
 <iframe src="https://blueprints.sublayer.com/interactive-code-generator/sublayer-triggers" width="100%" height="500px"></iframe>
 
-## Examples:
+## Real Use Cases
 
-- [FileChange](https://github.com/sublayerapp/sublayer/blob/main/lib/sublayer/triggers/file_change.rb): Activate agent when a file has changed.
+- **Continuous Integration Pipeline**: Using a FileChange trigger to start executing tests whenever a code file changes.
+- **Scheduled Reporting**: Implementing a TimeInterval trigger to generate and send reports daily or weekly.
+
+These are just examples of how you can implement triggers in practical scenarios, showcasing the flexibility and power triggers add to the agent's capability.
+


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Provide a detailed guide on creating and using Agents within the framework, showcasing examples from the codebase and explaining the Agent lifecycle and how Triggers work.
  description of file changes: - `docs/concepts/agents.md`: Expand with a 'Guide to Writing and Utilizing Agents'. 
- Illustrate with examples from `spec/agents/rspec_agent_spec.rb` showing step-by-step creation and running of Agents. 
- Detail how triggers activate Agents, utilizing real use cases from the repository.