### PR TITLE
Clarify LLM Provider Configuration

### DIFF
--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -6,6 +6,11 @@ nav_order: 6
 
 After installing Sublayer, you can choose between any of the available LLM providers we support.
 
+## Supported LLM Providers
+We currently support OpenAI, Claude, and Gemini as LLM providers.
+
+It is important to set the appropriate environment variables for each provider to function correctly.
+
 ## OpenAI (Default)
 
 Set your `OPENAI_API_KEY` environment variable. (Visit [OpenAI](https://openai.com/product) to get an API key.)
@@ -17,9 +22,10 @@ Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
 Sublayer.configuration.ai_model = "gpt-4o"
 ```
 
-## Anthropic
+Pitfall:
+Ensure that your API key is correct and active. Without a valid key, requests to OpenAI's API will fail.
 
-Supported Models: Claude 3+ Opus, Claude 3+ Haiku, Claude 3+ Sonnet
+## Claude
 
 Set your `ANTHROPIC_API_KEY` environment variable. (Visit [Anthropic](https://anthropic.com/) to get an API key.)
 
@@ -27,10 +33,13 @@ Usage:
 
 ```ruby
 Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
-Sublayer.configuration.ai_model = "claude-3-opus-20240229"
+Sublayer.configuration.ai_model = "claude-3-5-sonnet-20240620"
 ```
 
-## Google
+Pitfall:
+Ensure compatibility between the selected model and your usage requirements as different models support different features.
+
+## Gemini [UNSTABLE]
 
 Set your `GEMINI_API_KEY` environment variable. (Visit [Google AI Studio](https://ai.google.dev/) to get an API key.)
 
@@ -38,5 +47,28 @@ Usage:
 
 ```ruby
 Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
-Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
+Sublayer.configuration.ai_model = "gemini-1.5-pro"
 ```
+
+Pitfall:
+Gemini's API is in beta and may have undocumented changes that can affect stability. Proceed with caution in production environments.
+
+## Integration Example
+
+Here's a code example of integrating these providers into the Sublayer framework:
+
+```ruby
+# Example integration in a Ruby application
+
+require 'sublayer'
+
+# Setting up OpenAI as the provider
+Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+Sublayer.configuration.ai_model = "gpt-4o"
+
+# Example of making an AI model call
+result = Sublayer::Generators::SomeGenerator.new.some_method
+puts result
+```
+
+By setting up environment variables correctly and understanding each provider's specifics, you can leverage the power of LLMs in your Sublayer application.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
The current documentation on LLM provider configuration is outdated and lacks clarity. It should explicitly mention which providers are supported and provide examples for each, including potential pitfalls with their configuration. Furthermore, users should be informed about the importance of setting the correct environment variables for each provider and the implication of using them incorrectly.
  description of file changes: Updated sections in the `lib/sublayer/providers` directory that cover LLM provider configurations should include explicit documentation on setting provider-specific environment variables, detailing for OpenAI, Claude, and Gemini providers along with code examples of integrating them in the Sublayer framework. Furthermore, document how to handle API changes and configuration stability issues.