### PR TITLE
Clarify the Use of API Keys for Providers

### DIFF
--- a/docs/API_Key_Setup_Guide.md
+++ b/docs/API_Key_Setup_Guide.md
@@ -1,0 +1,39 @@
+---
+layout: default
+title: API Key Setup Guide
+parent: Guides
+nav_order: 6
+---
+
+# API Key Setup Guide
+
+To work with different API providers in your projects, it's essential to properly configure the API keys. This guide will help you set up API keys for our supported providers: OpenAI, Gemini, and Claude.
+
+## OpenAI
+
+- **Environment Variable:** `OPENAI_API_KEY`
+- **Where to get the API key?** Visit [OpenAI](https://openai.com/product) to obtain your API key.
+- **Setup**: Once you have the key, set it up in your environment by adding it to your shell configuration (`~/.bashrc`, `~/.zshrc`, etc.):
+  ```sh
+  export OPENAI_API_KEY="your-api-key"
+  ```
+
+## Gemini _(Unstable)_
+
+- **Environment Variable:** `GEMINI_API_KEY`
+- **Where to get the API key?** Visit [Google AI Studio](https://ai.google.dev/) to obtain your API key.
+- **Setup**: Add the key to your shell configuration file:
+  ```sh
+  export GEMINI_API_KEY="your-api-key"
+  ```  
+
+## Claude
+
+- **Environment Variable:** `ANTHROPIC_API_KEY`
+- **Where to get the API key?** Visit [Anthropic](https://anthropic.com/) to obtain your API key.
+- **Setup**: Add the key to your shell configuration file:
+  ```sh
+  export ANTHROPIC_API_KEY="your-api-key"
+  ```  
+
+Ensure these environment variables are set before starting your application to enable seamless interaction with the respective APIs. If using a deployment service, navigate to their environment settings section to set these up manually.

--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -2,9 +2,12 @@
 title: Advanced Config
 nav_order: 6
 ---
+
 # Advanced Config
 
 After installing Sublayer, you can choose between any of the available LLM providers we support.
+
+For setting up API keys, refer to our [API Key Setup Guide]({% link docs/API_Key_Setup_Guide.md %}).
 
 ## OpenAI (Default)
 


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
There is a mention of API keys for different providers scattered throughout the documentation, yet a consolidated guide specifically detailing how to set up these environment variables could prevent user confusion. Each provider's API key usage should be clarified and unified in one document.
  description of file changes: Create a new document named 'API_Key_Setup_Guide.md'. This guide should detail how to set up API keys for OpenAI, Gemini, and Claude, specifying where and how these keys should be stored. Link this page from the relevant parts of the main documentation pages to ensure users see it.