### PR TITLE
Clarify Default AI Models Usage

### DIFF
--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -2,41 +2,34 @@
 title: Advanced Config
 nav_order: 6
 ---
+
 # Advanced Config
 
 After installing Sublayer, you can choose between any of the available LLM providers we support.
 
-## OpenAI (Default)
+To avoid confusion, here is a list of default models for each provider:
 
-Set your `OPENAI_API_KEY` environment variable. (Visit [OpenAI](https://openai.com/product) to get an API key.)
+- **OpenAI**: The default model is `gpt-4o`. It is required to set your `OPENAI_API_KEY` environment variable. 
+  Usage:
+  ```ruby
+  Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+  Sublayer.configuration.ai_model = "gpt-4o"
+  ```
 
-Usage:
+- **Anthropic**: Models like Claude 3+ (e.g., Opus, Haiku, Sonnet) are supported. The `claude-3-opus-20240229` model can be started by setting `ANTHROPIC_API_KEY`. 
+  
+  Usage:
+  ```ruby
+  Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+  Sublayer.configuration.ai_model = "claude-3-opus-20240229"
+  ```
 
-```ruby
-Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
-Sublayer.configuration.ai_model = "gpt-4o"
-```
+- **Google**: Primarily uses the Gemini models, the default being `gemini-1.5-flash-latest`, with `GEMINI_API_KEY` required.
+  
+  Usage:
+  ```ruby
+  Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+  Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
+  ```
 
-## Anthropic
-
-Supported Models: Claude 3+ Opus, Claude 3+ Haiku, Claude 3+ Sonnet
-
-Set your `ANTHROPIC_API_KEY` environment variable. (Visit [Anthropic](https://anthropic.com/) to get an API key.)
-
-Usage:
-
-```ruby
-Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
-Sublayer.configuration.ai_model = "claude-3-opus-20240229"
-```
-
-## Google
-
-Set your `GEMINI_API_KEY` environment variable. (Visit [Google AI Studio](https://ai.google.dev/) to get an API key.)
-
-Usage:
-
-```ruby
-Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
-Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
-```
+Visit each provider's website for details on getting API keys.

--- a/docs/concepts/generators.md
+++ b/docs/concepts/generators.md
@@ -3,9 +3,16 @@ title: Generators
 parent: Core Concepts
 nav_order: 1
 ---
+
 # Generators
 
 Generators are responsible for generating specific outputs based on input data. They focus on a single generation task and do not perform any actions or complex decision-making. Generators are the building blocks of the Sublayer framework.
+
+Below are the compatible AI models typically used with these generator examples:
+
+- OpenAI's `gpt-4o` model is often used for general-purpose code generation tasks.
+- Gemini models are suitable for structured data transformations.
+- Claude models are adept at language understanding tasks.
 
 ### Try making your own generator:
 

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -2,12 +2,13 @@
 title: Core Concepts
 nav_order: 3
 ---
+
 # Core Concepts
 
 The framework is broken up into three core concepts: Generators, Actions, and Agents.
 
-Browse the links below to go more in depth into each of these concepts:
+Below, you will find links to each concept with descriptions of the default and other supported models:
 
-* [Generators]({% link docs/concepts/generators.md %})
-* [Actions]({% link docs/concepts/actions.md %})
-* [Agents]({% link docs/concepts/agents.md %})
+* [Generators]({% link docs/concepts/generators.md %}) - Supports models like OpenAI's `gpt-4o`, Gemini, and Claude which can be utilized for diverse generative tasks.
+* [Actions]({% link docs/concepts/actions.md %}) - An intermediary that does not depend on specific models but works seamlessly with any model output.
+* [Agents]({% link docs/concepts/agents.md %}) - Flexible entities that can be fine-tuned to any supported model, allowing autonomous task management.

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -2,6 +2,7 @@
 title: "Quick Start"
 nav_order: 2
 ---
+
 # Quick Start
 
 Sublayer is made up of three main concepts: Generators, Actions, and Agents. These concepts combine to create powerful AI-powered applications in a simple and easy-to-use interface.
@@ -28,7 +29,7 @@ gem "sublayer"
 
 ### Step 2 - Environment Setup
 
-Set your OpenAI API key as an environment variable:
+Set your API key as an environment variable. By default, Sublayer uses OpenAI's `gpt-4o` model as the default:
 
 ```shell
 export OPENAI_API_KEY="your-api-key"
@@ -65,11 +66,14 @@ module Sublayer
 
       def prompt
         <<-PROMPT
-          You are an expert programmer in \#{@technologies.join(", ")}.
+          You are an expert programmer in \
+          #{@technologies.join(', ')}.
 
-          You are tasked with writing code using the following technologies: \#{@technologies.join(", ")}.
+          You are tasked with writing code using the following technologies: \
+          #{@technologies.join(', ')}.
 
-          The description of the task is \#{@description}
+          The description of the task is \
+          #{@description}
 
           Take a deep breath and think step by step before you start coding.
         PROMPT
@@ -91,7 +95,7 @@ Try generating your own generator with our interactive code generator below:
 
 Require the Sublayer gem and your generator and call `generate`!
 
-Here's an example of how you might use the \`CodeFromDescriptionGenerator\` above:
+Here's an example of how you might use the `CodeFromDescriptionGenerator` above:
 
 ```ruby
 # ./example.rb


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Clarify the specified AI models for Sublayer, as described in the README.md when referring to updates in supported AI models like Gemini (beta version) and Claude. While the "gpt-4o" model is selected as the default model, this is not described in the concepts or framework sections. This discrepancy can create confusion among users regarding compatibility.
  description of file changes: 1. File: docs/advanced_config.md - Add a section clearly explaining the default models for each provider, emphasizing the use of OpenAI's 'gpt-4o' as the default.
2. File: docs/quick_start.md - Mention the default provider and model when demonstrating the initial setup.
3. File: docs/concepts/index.md - Highlight the specific AI models used in various examples to ensure clarity regarding which model supports what function.
4. File: docs/concepts/generators.md - Provide a brief explanation of specific models compatible with the generators examples.