### PR TITLE
Clarify Provider Configurations

### DIFF
--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,38 @@
+---
+title: Providers
+nav_order: 6
+---
+
+# Providers
+
+This section provides detailed setup instructions for the different AI providers supported by Sublayer, including OpenAI, Claude, and Gemini. Each provider has unique requirements for API keys and model configuration. Follow the examples below to set up each provider.
+
+## OpenAI (Default)
+
+OpenAI provides a suite of APIs for various functionalities. To use OpenAI services with Sublayer, set the `OPENAI_API_KEY` environment variable after obtaining it from [OpenAI](https://openai.com/product).
+
+Example configuration:
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+Sublayer.configuration.ai_model = "gpt-4o"
+```
+
+## Claude
+
+Claude is an AI platform offering several models. Set your `ANTHROPIC_API_KEY` environment variable to interact with Claude. Available at [Anthropic](https://anthropic.com/).
+
+Example configuration:
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+Sublayer.configuration.ai_model = "claude-3-opus-20240229"
+```
+
+## Gemini
+
+Gemini's APIs are currently in beta and experimental. Obtain your `GEMINI_API_KEY` from [Google AI Studio](https://ai.google.dev/). Note that the API is considered unstable.
+
+Example configuration:
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
+```

--- a/index.md
+++ b/index.md
@@ -22,3 +22,4 @@ Sublayer is self-assembling, model-agnostic, AI Agent framework in Ruby that all
 * [Examples]({% link docs/guides/index.md %}): Browse example code showing how you can use the Sublayer gem.
 * [Framework Guide]({% link docs/concepts/index.md %}): Learn about Sublayer concepts and conventions.
 * [Advanced Config]({% link docs/advanced_config.md %}): Step-by-step guides to setting up your system and installing the library.
+* [Providers]({% link docs/providers.md %}): Understand different AI providers supported by Sublayer and how to configure them.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Add a new section on 'Providers' in order to clarify the setup of different AI providers with examples of configuration code for each, reflecting the diverse providers supported by the system (OpenAI, Claude, Gemini), as this is an essential part of the framework usage and should be clearer for newcomers.
  description of file changes: In the file 'index.md' under the 'Quick Links' section, add a link to a new page titled 'Providers'. Create a new file 'docs/providers.md' with a detailed section for each provider, describing the setup process, API key requirements, and configuration examples. Include code snippets from 'README.md' for setting the `ai_provider` and `ai_model`. Ensure clear distinction of when each provider setup should be used, including a note on the stability of Gemini's API.