### PR TITLE
Enrich `llm_output_adapter` Usage Examples

### DIFF
--- a/docs/concepts/generators.md
+++ b/docs/concepts/generators.md
@@ -7,6 +7,53 @@ nav_order: 1
 
 Generators are responsible for generating specific outputs based on input data. They focus on a single generation task and do not perform any actions or complex decision-making. Generators are the building blocks of the Sublayer framework.
 
+## Output Adapters
+
+Output adapters in Sublayer define the structure and format of the AI-generated output. With these, you can tailor the output format to your needs.
+
+### Single String Adapter
+Outputs a single string.
+```ruby
+llm_output_adapter type: :single_string,
+  name: "generated_text",
+  description: "The generated text output"
+```
+
+### List of Strings Adapter
+Outputs an array of strings.
+```ruby
+llm_output_adapter type: :list_of_strings,
+  name: "list_of_codes",
+  description: "A list of generated codes"
+```
+
+### Named Strings Adapter
+Outputs a structured hash with each key as a descriptor of the string.
+```ruby
+llm_output_adapter type: :named_strings,
+  name: "detailed_code_info",
+  description: "Information about the codes",
+  attributes: [
+    { name: "language", description: "Programming language used" },
+    { name: "complexity", description: "Estimated complexity of the code" }
+  ]
+```
+
+### List of Named Strings Adapter
+Outputs an array of structured hashes.
+```ruby
+llm_output_adapter type: :list_of_named_strings,
+  name: "project_files_info",
+  description: "Information about each project file",
+  item_name: "file_info",
+  attributes: [
+    { name: "file_name", description: "Name of the file" },
+    { name: "lines_of_code", description: "Number of LOC in the file" }
+  ]
+```
+
+Using these adapters, you can efficiently manage the output from your Generators, ensuring it meets your application requirements.
+
 ### Try making your own generator:
 
 <iframe src="https://blueprints.sublayer.com/interactive-code-generator/sublayer-generators?example=true" width="100%" height="500px"></iframe>

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -2,6 +2,7 @@
 title: "Quick Start"
 nav_order: 2
 ---
+
 # Quick Start
 
 Sublayer is made up of three main concepts: Generators, Actions, and Agents. These concepts combine to create powerful AI-powered applications in a simple and easy-to-use interface.
@@ -79,7 +80,50 @@ module Sublayer
 end
 ```
 
-To learn more about everything you can do with a generator, check out the [Generators]({% link docs/concepts/generators.md %}) page.
+#### `llm_output_adapter` Types and Examples
+
+**Single String Adapter**: Outputs a single string.
+
+```ruby
+llm_output_adapter type: :single_string,
+  name: "generated_text",
+  description: "The generated text output"
+```
+
+**List of Strings Adapter**: Outputs an array of strings.
+
+```ruby
+llm_output_adapter type: :list_of_strings,
+  name: "list_of_codes",
+  description: "A list of generated codes"
+```
+
+**Named Strings Adapter**: Outputs a structured hash where each key is a descriptor of the string.
+
+```ruby
+llm_output_adapter type: :named_strings,
+  name: "detailed_code_info",
+  description: "Information about the codes",
+  attributes: [
+    { name: "language", description: "Programming language used" },
+    { name: "complexity", description: "Estimated complexity of the code" }
+  ]
+```
+
+**List of Named Strings Adapter**: Outputs an array of structured hashes.
+
+```ruby
+llm_output_adapter type: :list_of_named_strings,
+  name: "project_files_info",
+  description: "Information about each project file",
+  item_name: "file_info",
+  attributes: [
+    { name: "file_name", description: "Name of the file" },
+    { name: "lines_of_code", description: "Number of LOC in the file" }
+  ]
+```
+
+These examples will aid in structuring outputs effectively based on different generator requirements.
 
 ### Step 3b - Try Generating One!
 
@@ -91,7 +135,7 @@ Try generating your own generator with our interactive code generator below:
 
 Require the Sublayer gem and your generator and call `generate`!
 
-Here's an example of how you might use the \`CodeFromDescriptionGenerator\` above:
+Here's an example of how you might use the `CodeFromDescriptionGenerator` above:
 
 ```ruby
 # ./example.rb


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Update the `docs/quick_start.md` to elaborate more on the `llm_output_adapter` usage in Generators with detailed examples covering each adapter type. This will help users understand how to structure their generator outputs better using the appropriate adapter type.
  description of file changes: - Extend the current example in `docs/quick_start.md` to include various `llm_output_adapter` types with sample outputs and scenarios.
- Possibly create subsections for each adapter type within `docs/concepts/generators.md` offering detailed, illustrated examples or link to full example files in the code.