### PR TITLE
Introduce Comprehensive Guide on LLM Providers Usage

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -2,6 +2,7 @@
 title: Core Concepts
 nav_order: 3
 ---
+
 # Core Concepts
 
 The framework is broken up into three core concepts: Generators, Actions, and Agents.
@@ -11,3 +12,4 @@ Browse the links below to go more in depth into each of these concepts:
 * [Generators]({% link docs/concepts/generators.md %})
 * [Actions]({% link docs/concepts/actions.md %})
 * [Agents]({% link docs/concepts/agents.md %})
+* [LLM Providers]({% link docs/llm_providers.md %})

--- a/docs/llm_providers.md
+++ b/docs/llm_providers.md
@@ -1,0 +1,56 @@
+---
+layout: default
+title: LLM Providers
+nav_order: 7
+---
+
+# LLM Providers
+
+This section provides step-by-step instructions and considerations for setting up different LLM providers with Sublayer, including OpenAI, Gemini, and Claude.
+
+## OpenAI
+
+1. **Set up**: Ensure you have an OpenAI API key set in the `OPENAI_API_KEY` environment variable. Visit [OpenAI](https://openai.com/product) to get an API key.
+2. **Configuration**:
+   ```ruby
+   Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+   Sublayer.configuration.ai_model = "gpt-4o"
+   ```
+3. **Example Usage**:
+   ```ruby
+   # Example code snippet
+   Sublayer::Generators::YourGenerator.new.generate
+   ```
+
+## Claude
+
+1. **Set up**: Set your Claude API key in the `ANTHROPIC_API_KEY` environment variable. Visit [Anthropic](https://anthropic.com/) to get an API key.
+2. **Configuration**:
+   ```ruby
+   Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+   Sublayer.configuration.ai_model = "claude-3-5-sonnet-20240620"
+   ```
+3. **Example Usage**:
+   ```ruby
+   # Example code snippet
+   Sublayer::Generators::YourGenerator.new.generate
+   ```
+
+## Gemini
+
+1. **Set up**: Ensure your Gemini API key is set in the `GEMINI_API_KEY` environment variable. Visit [Google AI Studio](https://ai.google.dev/) to get an API key.
+2. **Configuration**:
+   ```ruby
+   Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+   Sublayer.configuration.ai_model = "gemini-1.5-pro"
+   ```
+3. **Example Usage**:
+   ```ruby
+   # Example code snippet
+   Sublayer::Generators::YourGenerator.new.generate
+   ```
+
+## Considerations and Limitations
+
+- **Gemini**: While Gemini offers unique feature sets, its function calling API is in beta and considered unstable for production environments.
+- Ensure each provider's model configuration aligns with your application's requirements.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Based on the absence of detailed examples and explanations about using different LLM Providers in Sublayer, there is a need to create a dedicated section outlining the steps and variations in setups for OpenAI, Gemini, and Claude. This can help users quickly understand how to leverage different providers according to their specific needs and enhance the flexibility of the framework in practical applications.
  description of file changes: 1. Create a new documentation file e.g., docs/llm_providers.md.
2. Within this file, provide step-by-step details for:
   - Setting up OpenAI, Claude, and Gemini with required configurations.
   - Example code snippets or commands for switching between providers.
   - Specific considerations or limitations per provider, such as Gemini's instability note.
3. Link this new file from the index.md as a major documentation resource.