### PR TITLE
Include Installation Troubleshooting for Non-Standard Systems

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,6 +2,7 @@
 layout: default
 title: Troubleshooting
 nav_order: 7
+has_toc: true
 ---
 
 # Troubleshooting
@@ -21,5 +22,29 @@ This document provides common error scenarios and troubleshooting tips to assist
 ### 3. Network Issues
 **Problem:** Network-related errors when calling external APIs.  
 **Solution:** Ensure that the API service is not down, verify that your system's firewall settings allow outbound traffic on required ports, and check your internet connection.
+
+
+## Installation on Non-Standard Systems
+
+This section provides guidance for troubleshooting installation issues on non-standard systems, such as Windows or unique Linux setups.
+
+### Common Issues on Windows
+
+#### Problem: Ruby Path Not Set Correctly
+**Solution:** Ensure the Ruby binaries are added to your system's PATH. You can do this by adding the Ruby 'bin' folder to your PATH environment variable.
+
+#### Problem: Bundler Errors due to SSL
+**Solution:** You might need to update the SSL certificates. Check the [Ruby on Windows guide](https://rubyinstaller.org/add-ons/openssl.html) for how to correctly set up SSL certificates.
+  
+#### Problem: Command Line Arguments not supported
+**Solution:** Ensure you are using a command prompt that supports required arguments, such as PowerShell or Git Bash.
+
+### Common Issues on Linux
+
+#### Problem: Incorrect Ruby Version
+**Solution:** Check for the required Ruby version in your project's Gemfile. Use a tool like `rbenv` or `rvm` to manage and install the correct Ruby version.
+
+#### Problem: Gem Installation Fails
+**Solution:** Ensure you have the necessary build tools and libraries. This might include packages like `build-essential` and `libssl-dev` for Ubuntu systems.
 
 [Join our community Discord channel](https://discord.gg/TvgHDNEGWa).


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Include a troubleshooting section specifically for errors related to installations and configurations in non-standard systems like Windows. This would be invaluable for less common operating systems where installation paths, environment variables, or dependency requirements might differ slightly. This widens Sublayer's accessibility.
  description of file changes: In 'docs/troubleshooting.md', add a section titled 'Installation on Non-Standard Systems'. Provide FAQs, common error messages, and solutions or workarounds specific to alternate environments like Windows or different versions of Linux distributions.