### PR TITLE
Document Ruby Version Compatibility

### DIFF
--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -40,3 +40,24 @@ Usage:
 Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
 Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
 ```
+
+## Ruby Version Compatibility
+
+Sublayer is compatible with the following Ruby versions based on the `sublayer.gemspec` specifications:
+
+- Ruby 2.6
+- Ruby 2.7
+- Ruby 3.0
+- Ruby 3.1
+
+### Additional Dependencies and Settings
+
+When using certain Ruby versions, additional gems may be necessary. For example:
+
+- For Ruby versions greater than 3.0, ensure that the `webrick` gem is included when using Jekyll <= 4.2.2. This is indicated in the Gemfile comments as requirements for different Ruby versions.
+
+```ruby
+gem "webrick", "~> 1.7"
+```
+
+Make sure to check the Gemfile and your specific Ruby version requirements to maintain compatibility.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Introduce a new section in the documentation focused on Ruby version compatibility. Ensuring users know which Ruby versions are supported by Sublayer can avoid a host of integration issues, especially given the note in the Gemfile about the necessity of different gems for various Ruby versions.
  description of file changes: 1. In `docs/advanced_config.md`, create a new section called 'Ruby Version Compatibility'. 
2. List all compatible Ruby versions with the Sublayer library as per the `sublayer.gemspec` file.
3. Provide details on any additional dependencies or settings needed for specific Ruby versions.