### PR TITLE
Extending AI Provider Support Documentation

### DIFF
--- a/docs/custom_components/custom-providers.md
+++ b/docs/custom_components/custom-providers.md
@@ -1,0 +1,38 @@
+---
+title: Custom Providers
+parent: Custom Components
+nav_order: 3
+---
+# Custom Providers
+
+The Sublayer framework allows you to integrate custom AI providers in addition to the default ones offered by the system. This guide will walk you through the steps necessary to add a new provider using hooks and configuration settings.
+
+## Overview
+Integrating custom AI providers involves configuring the necessary API endpoints, setting up authentication, and ensuring that your provider's outputs can be processed within the Sublayer framework.
+
+## Step-by-Step Guide
+
+1. **Locate Provider Configurations:**
+   - Navigate to the `lib/sublayer/providers` directory. This contains the base configuration and existing implementations for current AI providers.
+
+2. **Create a New Provider Class:**
+   - Using the existing providers as a reference, create a new Ruby class for your provider. Ensure this class implements the necessary API calls and response handling.
+
+3. **Set Environment Variables: **
+   - Add any required environment variables for API keys or tokens. Ensure these are added to your `.env` file or your server's environment configuration.
+
+4. **Modify Configuration File:**
+   - Update your project's configuration to include the new provider.
+
+   ```ruby
+   Sublayer.configuration.ai_provider = Sublayer::Providers::YourCustomProvider
+   Sublayer.configuration.ai_model = "model-name"
+   ```
+
+5. **Testing:**
+   - Thoroughly test your provider to ensure it correctly interacts with the Sublayer framework and your application business logic.
+
+6. **Documentation:**
+   - Document any unique setup steps or configurations required for your provider in your application's README or a dedicated documentation page.
+
+By following these steps, you can extend the capabilities of Sublayer to use AI models of your choice, catering to specific application requirements or preferences.

--- a/docs/custom_components/index.md
+++ b/docs/custom_components/index.md
@@ -8,3 +8,4 @@ The Sublayer framework is designed to be extensible and customizable. Beyond jus
 
 * [Output Adapters]({% link docs/custom_components/output-adapters.md %})
 * [Triggers]({% link docs/custom_components/triggers.md %})
+* [Custom Providers]({% link docs/custom_components/custom-providers.md %})  <!-- New link added -->


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Introduce new documentation for customizing AI providers beyond OpenAI, Claude, and Gemini. Document steps to add new providers by leveraging hooks and configuration adjustments as seen in lib/sublayer/providers. This documentation is crucial for advanced users needing flexibility with AI models outside the default offers and those willing to integrate lesser-known APIs.
  description of file changes: File: docs/custom_components/index.md - Add a subsection 'Custom Providers' with detailed instructions on introducing a new provider using existing code in lib/sublayer/providers as a reference point.