### PR TITLE
Add Missing Information on Providers and Models

### DIFF
--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -27,7 +27,7 @@ Usage:
 
 ```ruby
 Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
-Sublayer.configuration.ai_model = "claude-3-opus-20240229"
+Sublayer.configuration.ai_model = "claude-3-5-sonnet-20240620"
 ```
 
 ## Google

--- a/docs/concepts/generators.md
+++ b/docs/concepts/generators.md
@@ -7,15 +7,46 @@ nav_order: 1
 
 Generators are responsible for generating specific outputs based on input data. They focus on a single generation task and do not perform any actions or complex decision-making. Generators are the building blocks of the Sublayer framework.
 
+### Supported AI Models
+
+Sublayer supports the following AI models for generators:
+
+#### OpenAI Models
+- **gpt-4o**: The default model for high-quality text generation.
+
+Example usage:
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
+Sublayer.configuration.ai_model = "gpt-4o"
+```
+
+#### Claude Models
+- **claude-3-5-sonnet-20240620**: Useful for creative text generation tasks.
+
+Example usage:
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Claude
+Sublayer.configuration.ai_model = "claude-3-5-sonnet-20240620"
+```
+
+#### Gemini Models
+- **gemini-1.5-flash-latest**: Suitable for rapid iteration and testing.
+
+Example usage:
+```ruby
+Sublayer.configuration.ai_provider = Sublayer::Providers::Gemini
+Sublayer.configuration.ai_model = "gemini-1.5-flash-latest"
+```
+
 ### Try making your own generator:
 
 <iframe src="https://blueprints.sublayer.com/interactive-code-generator/sublayer-generators?example=true" width="100%" height="500px"></iframe>
 
 ### [Examples](https://github.com/sublayerapp/sublayer/tree/main/examples):
 
-* [CodeFromDescriptionGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code\_from\_description\_generator.rb): Generates code based on a description and the technologies used.
-* [DescriptionFromCodeGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/description\_from\_code\_generator.rb): Generates a description of the code passed in to it.
-* [CodeFromBlueprintGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code\_from\_blueprint\_generator.rb): Generates code based on a blueprint, a blueprint description, and a description of the desired code.
+* [CodeFromDescriptionGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code_from_description_generator.rb): Generates code based on a description and the technologies used.
+* [DescriptionFromCodeGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/description_from_code_generator.rb): Generates a description of the code passed in to it.
+* [CodeFromBlueprintGenerator](https://github.com/sublayerapp/sublayer/blob/main/examples/code_from_blueprint_generator.rb): Generates code based on a blueprint, a blueprint description, and a description of the desired code.
 
 ### Troubleshooting
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,4 +22,8 @@ This document provides common error scenarios and troubleshooting tips to assist
 **Problem:** Network-related errors when calling external APIs.  
 **Solution:** Ensure that the API service is not down, verify that your system's firewall settings allow outbound traffic on required ports, and check your internet connection.
 
+### 4. AI Model Configuration Issues
+**Problem:** Unexpected behavior or errors when configuring AI models.  
+**Solution:** Double-check the specified model name in the configuration code. Refer to the documentation for each provider to ensure compatibility and current support. Ensure that the API key used matches the provider of the configured model.
+
 [Join our community Discord channel](https://discord.gg/TvgHDNEGWa).


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
The current documentation does not fully reflect the supported AI models within the sublayer framework. Specifically, it lacks up-to-date details about the newly supported models, like OpenAI's "gpt-4o" as a default, Claude's "claude-3-5-sonnet-20240620", and Gemini's "gemini-1.5-flash-latest". This could lead to confusion regarding what models are available and how to configure them.
  description of file changes: 1. **docs/advanced_config.md**: Include details on how to configure and use the updated models mentioned above, with example configurations.
2. **docs/concepts/generators.md**: Add a section listing the available AI providers and models in the context of Generators, explaining the contextual usage of each supported model.
3. **docs/troubleshooting.md**: Ensure there are troubleshooting steps relevant to the use of different AI models and common issues that might arise when switching providers.