### PR TITLE
Expand Documentation on CLI Tool Usage

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -10,6 +10,9 @@ You can think of a Sublayer Generator as an object that takes some string inputs
 
 In this example, we'll create a simple generator that takes a description of code and the technologies to use and generates code using an LLM like GPT-4.
 
+## CLI Tool Overview
+The Sublayer CLI tool is a powerful utility designed to simplify the initialization and management of Sublayer components, such as actions, agents, and projects. With just a few commands, the CLI tool can help you scaffold new projects, generate component templates, and manage your AI-driven workflows seamlessly. This quick-start guide emphasizes the efficiency of using the CLI tool in setting up your development environment quickly and effectively.
+
 ***
 
 ### Step 1 - Installation


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Include notes and guides on using the CLI tool, particularly for generating actions, agents, and projects. Given that a CLI tool is available to simplify generating Sublayer components, users could greatly benefit from a quick-start style guide or expanded tutorial on using this functionality effectively.
  description of file changes: File: docs/quick_start.md
- Briefly introduce the CLI tool and mention its capabilities in simplifying setup and generation processes.

File: docs/resources/index.md
- Add a section titled 'Using the CLI Tool' that includes details on setting up and executing the CLI tool, especially for generating various Sublayer components.

File: docs/guides/index.md
- Create a new guide focusing on the CLI tool functionality, possibly including video content or images of the CLI in use, showing how to start a new project or add components quickly using it.