### PR TITLE
Document Custom Provider Creation and Integration

### DIFF
--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -4,10 +4,11 @@ nav_order: 3
 ---
 # Core Concepts
 
-The framework is broken up into three core concepts: Generators, Actions, and Agents.
+The framework is broken up into four core concepts: Generators, Actions, Agents, and Providers.
 
 Browse the links below to go more in depth into each of these concepts:
 
 * [Generators]({% link docs/concepts/generators.md %})
 * [Actions]({% link docs/concepts/actions.md %})
 * [Agents]({% link docs/concepts/agents.md %})
+* [Providers]({% link docs/concepts/providers.md %})

--- a/docs/concepts/providers.md
+++ b/docs/concepts/providers.md
@@ -1,0 +1,49 @@
+---
+layout: default
+title: Providers
+parent: Core Concepts
+nav_order: 4
+---
+
+# Providers
+
+The purpose of this documentation is to guide you on how to create and integrate custom Providers into the Sublayer framework to allow seamless integration of different AI models.
+
+## Setting Up Environment Variables
+
+To securely access external AI services, define specific environment variables for API keys. For example:
+
+```shell
+export CUSTOM_AI_API_KEY="your-api-key"
+```
+
+## Declaring New Provider Classes
+
+To declare a new Provider, you need to create a class under `Sublayer::Providers`. Here is a basic structure of a Provider class:
+
+```ruby
+module Sublayer
+  module Providers
+    class CustomAI
+      def self.call(prompt:, output_adapter:)
+        # Add logic to send a prompt to the AI service
+        # Return the processed result
+      end
+    end
+  end
+end
+```
+
+- **call method**: The `call` method should handle sending a prompt to the AI model and returning the result.
+
+## Integrating Providers with Generators and Actions
+
+To use your custom Provider with the existing Generators and Actions:
+
+1. **Configuration**: Set the provider in your configuration file:
+   ```ruby
+   Sublayer.configuration.ai_provider = Sublayer::Providers::CustomAI
+   ```
+2. **Implement as needed**: Add any specific integration logic required for your Provider model.
+
+This setup allows you to extend the capabilities of the Sublayer framework by leveraging different AI models.


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
The documentation currently lacks a clear and comprehensive explanation of how to create and use custom Providers in the Sublayer framework. Given the model-agnostic nature of Sublayer, users should be able to seamlessly integrate different AI models by defining their own provider configurations. This documentation should cover how to declare new Provider classes, use environment variables for API keys, and integrate these providers with existing Generators and Actions.
  description of file changes: Add a new file named 'docs/concepts/providers.md' explaining the steps to create custom Providers for new AI models. This document should include sections on setting up environment variables, the structure of a Provider class, and examples of integrating these providers within the Sublayer framework. Update 'docs/concepts/index.md' to include a link to this new Providers page.