### PR TITLE
Document Extending Sublayer with Custom Components

### DIFF
--- a/docs/custom_components/custom_output_adapter.md
+++ b/docs/custom_components/custom_output_adapter.md
@@ -1,0 +1,48 @@
+---
+title: Custom Output Adapter
+parent: Custom Components
+nav_order: 4
+---
+# Custom Output Adapter
+
+Output adapters are a mechanism in the Sublayer framework that define how the response from an AI model is transformed and returned. Creating a custom output adapter allows you to define new types of outputs tailored specifically to your application's needs.
+
+## Creating a Custom Output Adapter
+
+1. **Define the Adapter Class**
+   - Define a new class under the `Sublayer::Components::OutputAdapters` module.
+   - Implement required methods like `initialize`, `properties`, and optionally, `materialize_result`.
+
+2. **Adapter Properties**
+   - Use the `properties` method to define the expected structure and types of the model's response.
+
+3. **Integrate with Generators**
+   - Pass your custom output adapter to a generator using the `llm_output_adapter` directive.
+
+## Example
+```ruby
+module Sublayer
+  module Components
+    module OutputAdapters
+      class CustomAdapter
+        attr_reader :name, :description
+
+        def initialize(options)
+          @name = options[:name]
+          @description = options[:description]
+        end
+
+        def properties
+          [OpenStruct.new(name: @name, type: 'custom', description: @description, required: true)]
+        end
+
+        def materialize_result(raw_result)
+          # Process raw_result according to custom logic
+        end
+      end
+    end
+  end
+end
+```
+
+By defining custom output adapters in this way, you can leverage Sublayer's flexibility to suit varied application requirements, standardizing the structure and format of information received from AI models.

--- a/docs/custom_components/custom_provider.md
+++ b/docs/custom_components/custom_provider.md
@@ -1,0 +1,51 @@
+---
+title: Custom Provider
+parent: Custom Components
+nav_order: 3
+---
+# Custom Provider
+
+Creating a custom provider allows you to integrate different AI models into the Sublayer framework. By defining a new provider, you can customize how requests are made to the AI model and how responses are processed.
+
+## Step-by-Step Guide to Creating a Custom Provider
+
+1. **Define the Provider Class**
+   - Start by creating a new Ruby class for your provider under the `Sublayer::Providers` module.
+   - The class should have a `self.call` class method, which takes `prompt:` and `output_adapter:` as arguments.
+
+2. **Setup API Requests**
+   - Utilize libraries such as `HTTParty` to handle API requests.
+   - Define the API endpoint URL and request parameters.
+
+3. **Process API Responses**
+   - Upon receiving a response, process the data to extract the necessary information as per your application's needs.
+
+4. **Configuration**
+   - Add your provider to the Sublayer configuration using `Sublayer.configuration.ai_provider`.
+
+5. **Comprehensive Example**
+   - Refer to existing provider implementations like `OpenAI`, `Claude`, and `Gemini` in the `lib/sublayer/providers` directory for an in-depth example.
+
+## Example
+```ruby
+module Sublayer
+  module Providers
+    class CustomAI
+      def self.call(prompt:, output_adapter:)
+        response = HTTParty.post(
+          "https://api.customai.com/process",
+          body: {
+            "prompt": prompt,
+            "output": output_adapter.structure
+          }.to_json,
+          headers: { "Content-Type" => "application/json" }
+        )
+
+        response["result"]  # Example key to fetch data
+      end
+    end
+  end
+end
+```
+
+By following these steps, you can seamlessly integrate a new AI model into Sublayer, tailoring the provider to meet specific application requirements.

--- a/docs/custom_components/custom_trigger.md
+++ b/docs/custom_components/custom_trigger.md
@@ -1,0 +1,36 @@
+---
+title: Custom Trigger
+parent: Custom Components
+nav_order: 5
+---
+# Custom Trigger
+
+Triggers in the Sublayer framework specify events that activate an agent to perform tasks. By creating custom triggers, you can expand Sublayer's ability to react to an extensive variety of conditions or events.
+
+## Steps to Create a Custom Trigger
+
+1. **Build the Trigger Class**
+   - Define a new class inheriting `Sublayer::Triggers::Base`.
+   - Implement the `setup` method to configure the event listening logic.
+
+2. **Linking Triggers with Agents**
+   - Integrate the trigger with an agent by using it in the `trigger` method of the agent.
+
+3. **Example**
+```ruby
+module Sublayer
+  module Triggers
+    class CustomEventTrigger < Base
+      def initialize(event_condition)
+        @event_condition = event_condition
+      end
+
+      def setup(agent)
+        # Logic to start listening or watching for @event_condition and call activate(agent) when met
+      end
+    end
+  end
+end
+```
+
+By developing custom triggers, agents can be tailored to respond to specific scenarios as dictated by dynamic application requirements, ensuring timely execution of actions.

--- a/docs/custom_components/index.md
+++ b/docs/custom_components/index.md
@@ -8,3 +8,6 @@ The Sublayer framework is designed to be extensible and customizable. Beyond jus
 
 * [Output Adapters]({% link docs/custom_components/output-adapters.md %})
 * [Triggers]({% link docs/custom_components/triggers.md %})
+* [Custom Provider]({% link docs/custom_components/custom_provider.md %})
+* [Custom Output Adapter]({% link docs/custom_components/custom_output_adapter.md %})
+* [Custom Trigger]({% link docs/custom_components/custom_trigger.md %})


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Update documentation to include the strategies for extending Sublayer with custom components like Providers, Output Adapters, and Triggers, providing code examples and detailed instructions.
  description of file changes: Extend existing sections in docs/custom_components/index.md and create new files if necessary:
1. docs/custom_components/custom_provider.md that demonstrates creating a custom provider.
2. docs/custom_components/custom_output_adapter.md for building a custom output adapter.
3. docs/custom_components/custom_trigger.md to illustrate creating custom triggers with examples.
Use code examples from files like lib/sublayer/cli/commands/generators/sublayer_action_generator.rb as references.
