### PR TITLE
Clarify OpenAI Configuration and Update AI Model Information

### DIFF
--- a/docs/advanced_config.md
+++ b/docs/advanced_config.md
@@ -17,6 +17,8 @@ Sublayer.configuration.ai_provider = Sublayer::Providers::OpenAI
 Sublayer.configuration.ai_model = "gpt-4o"
 ```
 
+The default AI model used is `gpt-4o`. Ensure you have correctly set the `OPENAI_API_KEY` within your environment variables to allow the application to authenticate and make requests to OpenAI's services. You can configure the AI model by setting the `Sublayer.configuration.ai_model` to another model supported by OpenAI, should you choose to.
+
 ## Anthropic
 
 Supported Models: Claude 3+ Opus, Claude 3+ Haiku, Claude 3+ Sonnet


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Update the 'OpenAI' section to reflect the current default AI model, which is 'gpt-4o'. Ensure there is no mention of deprecated models and clarify the setup process to prevent confusion among users.
  description of file changes: In 'docs/advanced_config.md', update the OpenAI section to state that the default AI model is 'gpt-4o'. Ensure that the instructions clearly state how to configure the environment variables for the respective AI models, focusing on the necessary setup steps for OpenAI.