### PR TITLE
Expand Quick Start with Multi-Provider Setup

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -36,6 +36,26 @@ export OPENAI_API_KEY="your-api-key"
 
 Don't have a key? Visit [OpenAI](https://openai.com/product) to get one.
 
+##### Claude Setup
+
+Set your Claude API key as an environment variable:
+
+```shell
+export ANTHROPIC_API_KEY="your-claude-api-key"
+```
+
+Don't have a key? Visit [Anthropic](https://anthropic.com/) to get one.
+
+##### Gemini Setup
+
+Set your Gemini API key as an environment variable:
+
+```shell
+export GEMINI_API_KEY="your-gemini-api-key"
+```
+
+Don't have a key? Visit [Google AI Studio](https://ai.google.dev/) to get one.
+
 ### Step 3a - Create a Generator
 
 Create a Sublayer Generator. Generators are responsible for taking input from your application and generating output using an LLM like GPT-4.
@@ -65,11 +85,11 @@ module Sublayer
 
       def prompt
         <<-PROMPT
-          You are an expert programmer in \#{@technologies.join(", ")}.
+          You are an expert programmer in \\#{@technologies.join(", ")}.
 
-          You are tasked with writing code using the following technologies: \#{@technologies.join(", ")}.
+          You are tasked with writing code using the following technologies: \\#{@technologies.join(", ")}.
 
-          The description of the task is \#{@description}
+          The description of the task is \\#{@description}
 
           Take a deep breath and think step by step before you start coding.
         PROMPT
@@ -91,7 +111,7 @@ Try generating your own generator with our interactive code generator below:
 
 Require the Sublayer gem and your generator and call `generate`!
 
-Here's an example of how you might use the \`CodeFromDescriptionGenerator\` above:
+Here's an example of how you might use the `CodeFromDescriptionGenerator` above:
 
 ```ruby
 # ./example.rb


### PR DESCRIPTION
This PR contains daily documentation updates based on the following suggestion:
Update the Quick Start guide to include setup instructions for different LLM providers like Claude and Gemini. It currently shows an example using OpenAI only, which might limit users who want to use different providers.
  description of file changes: docs/quick_start.md: Add sections under 'Environment Setup' to cover setting API keys for Claude and Gemini, similar to the existing OpenAI section. Under 'Create a Generator', provide equivalent `Sublayer.configuration` example code for Claude and Gemini models.