### PR TITLE
Fix Ruby syntax on quickstart page

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -65,11 +65,11 @@ module Sublayer
 
       def prompt
         <<-PROMPT
-          You are an expert programmer in \#{@technologies.join(", ")}.
+          You are an expert programmer in #{@technologies.join(", ")}.
 
-          You are tasked with writing code using the following technologies: \#{@technologies.join(", ")}.
+          You are tasked with writing code using the following technologies: #{@technologies.join(", ")}.
 
-          The description of the task is \#{@description}
+          The description of the task is #{@description}
 
           Take a deep breath and think step by step before you start coding.
         PROMPT


### PR DESCRIPTION
The backslashes cause the interpolation to fail, e.g. it outputs:

```
1. **Identify Technologies**:
   - First, we need to determine what #{@technologies.join(", ")} represents. Let's assume it's a list of technologies like 'JavaScript, Node.js, Express'.
```